### PR TITLE
removed node_modules from webpack scss loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     }
   ],
   "dependencies": {
-    "autoprefixer": "^6.4.1",
+    "autoprefixer": "^6.7.0",
     "autoprefixer-loader": "^3.2.0",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
@@ -55,7 +55,7 @@
     "babel-preset-travix": "^1.1.0",
     "babel-register": "^6.16.3",
     "css-loader": "^0.26.1",
-    "extract-text-webpack-plugin": "~1.0.1",
+    "extract-text-webpack-plugin": "^1.0.1",
     "node-sass": "^4.3.0",
     "postcss-loader": "^1.2.2",
     "react": "^0.14.8",
@@ -63,14 +63,14 @@
     "sass-loader": "^4.0.1",
     "style-loader": "^0.13.1",
     "theme-builder": "^0.2.1",
-    "webpack": "~1.13.0"
+    "webpack": "^1.13.0"
   },
   "devDependencies": {
     "cheerio": "^0.22.0",
     "coveralls": "^2.11.12",
-    "enzyme": "^2.5.1",
+    "enzyme": "^2.7.1",
     "enzyme-to-json": "^1.1.4",
-    "eslint": "^3.9.1",
+    "eslint": "^3.14.0",
     "eslint-config-travix": "^2.2.0",
     "eslint-plugin-babel": "^4.0.0",
     "eslint-plugin-import": "^2.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,6 @@ module.exports = {
       },
       {
         test: /\.s?css$/i,
-        exclude: /(node_modules)/,
         loader: ExtractTextPlugin.extract('style', ['css', 'postcss', 'sass']),
       },
     ],


### PR DESCRIPTION
## What does this PR do:
* updates packages versions (greenkeeper updates)
* removes node_modules from scss loader in webpack because of build problems when loading the package as a npm module.

## Where should the reviewer start:
* differences