### PR TITLE
Updated mods helper and class names according to the new BEM standards

### DIFF
--- a/components/_helpers.js
+++ b/components/_helpers.js
@@ -1,4 +1,4 @@
-const modSep = '--';
+const modSep = '_';
 
 function getClassNamesWithMods(baseClass, mods = []) {
   baseClass = [].concat(baseClass);

--- a/components/button/button.scss
+++ b/components/button/button.scss
@@ -23,7 +23,7 @@ $text-shadow: null !default;
   transition: all .1s ease-in-out;
 }
 
-.ui-button--variation_default {
+.ui-button_variation_default {
   font-family: $tx-generic-font-primary-font-family, $tx-generic-font-primary-generic-family;
   font-weight: $tx-generic-font-primary-weight-bold;
   font-size: 23px;
@@ -52,10 +52,10 @@ $text-shadow: null !default;
   }
 }
 
-.ui-button--disabled_true,
-.ui-button--disabled_true:focus,
-.ui-button--disabled_true:hover,
-.ui-button--disabled_true:active {
+.ui-button_disabled_true,
+.ui-button_disabled_true:focus,
+.ui-button_disabled_true:hover,
+.ui-button_disabled_true:active {
   color: $tx-button-color-disabled-text;
   cursor: default;
   background-color: $tx-button-color-disabled-bg-bottom;
@@ -65,26 +65,26 @@ $text-shadow: null !default;
   position: static;
 }
 
-.ui-button--size_xs {
+.ui-button_size_xs {
   font-size: 15px;
   padding: 3px 6px;
 }
-.ui-button--size_s {
+.ui-button_size_s {
   font-size: 18px;
   padding: 5px 10px;
 }
 
-.ui-button--size_m {
+.ui-button_size_m {
   font-size: 22px;
   padding: 0 24px;
   line-height: 40px;
 }
 
-.ui-button--size_l {
+.ui-button_size_l {
   font-size: 26px;
   padding: 12px 17px;
 }
-.ui-button--size_xl {
+.ui-button_size_xl {
   font-size: 28px;
   padding: 15px 20px;
 }

--- a/components/spinner/spinner.scss
+++ b/components/spinner/spinner.scss
@@ -5,27 +5,27 @@
   display: inline-block;
 }
 
-.ui-spinner--size_xs {
+.ui-spinner_size_xs {
   height: 25px;
   width: 25px;
 }
 
-.ui-spinner--size_s {
+.ui-spinner_size_s {
   height: 37px;
   width: 37px;
 }
 
-.ui-spinner--size_m {
+.ui-spinner_size_m {
   height: 50px;
   width: 50px;
 }
 
-.ui-spinner--size_l {
+.ui-spinner_size_l {
   height: 75px;
   width: 75px;
 }
 
-.ui-spinner--size_xl {
+.ui-spinner_size_xl {
   height: 100px;
   width: 100px;
 }

--- a/tests/unit/button/__snapshots__/button.spec.js.snap
+++ b/tests/unit/button/__snapshots__/button.spec.js.snap
@@ -1,6 +1,6 @@
 exports[`Button #render() should return base class with mods for strings as class and string as mods 1`] = `
 <a
-  className="ui-button ui-button--size_xs ui-button--variation_default ui-button--disabled_true"
+  className="ui-button ui-button_size_xs ui-button_variation_default ui-button_disabled_true"
   data-gtm="id"
   href="http://google.com">
   Extra small
@@ -13,7 +13,7 @@ exports[`Button #render() should return base class with mods for strings as clas
 
 exports[`Button #render() should return base class with mods for strings as class and string as mods 4`] = `
 <button
-  className="ui-button ui-button--size_xs ui-button--variation_default"
+  className="ui-button ui-button_size_xs ui-button_variation_default"
   data-gtm="id"
   disabled={false}
   type="submit">
@@ -23,7 +23,7 @@ exports[`Button #render() should return base class with mods for strings as clas
 
 exports[`Button #render() should return base class with mods for strings as class and string as mods 5`] = `
 <button
-  className="ui-button ui-button--size_xs ui-button--variation_default"
+  className="ui-button ui-button_size_xs ui-button_variation_default"
   disabled={false}
   onClick={[Function]}
   type="button">

--- a/tests/unit/helpers/helpers.spec.js
+++ b/tests/unit/helpers/helpers.spec.js
@@ -3,10 +3,10 @@ const getClassNamesWithMods = require('../../../components/_helpers.js').getClas
 describe('helpers', () => {
   describe('#getClassNamesWithMods()', () => {
     it('#1 should return class with mods for strings as class and array as mods', () => {
-      expect(getClassNamesWithMods('test', ['first', 'second'])).toBe('test test--first test--second');
+      expect(getClassNamesWithMods('test', ['first', 'second'])).toBe('test test_first test_second');
     });
     it('#2 should return class with mods for strings as array of classes and array as mods', () => {
-      expect(getClassNamesWithMods(['test', 'test2'], ['first', 'second'])).toBe('test test2 test--first test--second');
+      expect(getClassNamesWithMods(['test', 'test2'], ['first', 'second'])).toBe('test test2 test_first test_second');
     });
   });
 });

--- a/tests/unit/spinner/__snapshots__/spinner.spec.js.snap
+++ b/tests/unit/spinner/__snapshots__/spinner.spec.js.snap
@@ -1,6 +1,6 @@
 exports[`Spinner #render() should return base class with mods for strings as class and string as mods 1`] = `
 <div
-  className="ui-spinner ui-spinner--size_xs">
+  className="ui-spinner ui-spinner_size_xs">
   <svg
     styles="enable-background:new 0 0 80 80;"
     version="1.1"
@@ -87,7 +87,7 @@ exports[`Spinner #render() should return base class with mods for strings as cla
 
 exports[`Spinner #render() should return base class with mods for strings as class and string as mods 2`] = `
 <div
-  className="ui-spinner ui-spinner--size_m">
+  className="ui-spinner ui-spinner_size_m">
   <svg
     styles="enable-background:new 0 0 80 80;"
     version="1.1"


### PR DESCRIPTION
Updated according to the new BEM standards (see [here](https://en.bem.info/methodology/quick-start/#modifier))

Modified:
- mods helper.js 
- modifiers class names
- unit tests

Modifiers were changed from `block-name--modifier` to `block-name_modifier`