### PR TITLE
Improvement of the builder watcher

### DIFF
--- a/builder/generateThemeFile.js
+++ b/builder/generateThemeFile.js
@@ -17,8 +17,12 @@ module.exports = (yamlFile) => {
         return;
       }
 
-      const themeChunks = themeBuilder(content, 'scss', { prefix: 'tx' });
-      resolve(themeChunks.join('\n'));
+      try {
+        const themeChunks = themeBuilder(content, 'scss', { prefix: 'tx' });
+        resolve(themeChunks.join('\n'));
+      } catch (e) {
+        reject(e);
+      }
     });
   }).then(saveThemeScssFile);
 };

--- a/builder/getStylesAndSaveTheme.js
+++ b/builder/getStylesAndSaveTheme.js
@@ -18,7 +18,7 @@ module.exports = (themeFile, isWatchEnabled) => new Promise((resolve, reject) =>
     fs.watchFile(yamlFile, () => {
       generateThemeFile(yamlFile)
         .then(() => {
-          console.log(`Detected changes on ${yamlFile} and rebuilt themes/theme.scss`);
+          console.log(`Detected changes on ${yamlFile} and rebuilt themes/theme.scss`); // eslint-disable-line
         })
         .catch(console.error); // eslint-disable-line
     });

--- a/builder/getStylesAndSaveTheme.js
+++ b/builder/getStylesAndSaveTheme.js
@@ -15,9 +15,12 @@ module.exports = (themeFile, isWatchEnabled) => new Promise((resolve, reject) =>
   const yamlFile = themeFile || path.join(__dirname, '..', 'themes', '_default.yaml');
 
   if (isWatchEnabled) {
-    fs.watch(yamlFile, { persistent: true }, () => {
-      /** TODO: Do proper error handling on watch mode */
-      generateThemeFile(yamlFile).catch(reject);
+    fs.watchFile(yamlFile, () => {
+      generateThemeFile(yamlFile)
+        .then(() => {
+          console.log(`Detected changes on ${yamlFile} and rebuilt themes/theme.scss`);
+        })
+        .catch(console.error); // eslint-disable-line
     });
   }
 

--- a/tests/unit/builder/generateThemeFile.spec.js
+++ b/tests/unit/builder/generateThemeFile.spec.js
@@ -50,4 +50,23 @@ describe('Builder › generateThemeFile.js', () => {
         expect(err.message).toBe('Read error');
       });
   });
+
+  it('rejects when themeBuilder throws an error', () => {
+    const fakeFile = 'fake/file.yml';
+    fs.readFile.mockImplementation((filePath, options, cb) => cb(null, 'fake file content'));
+    themeBuilder.mockImplementation(() => { throw new Error('ThemeBuilder error'); });
+    return generateThemeFile(fakeFile)
+      .catch((err) => {
+        expect(fs.readFile).toHaveBeenCalled();
+        expect(fs.readFile.mock.calls[0][0]).toBe(fakeFile);
+        expect(fs.readFile.mock.calls[0][1]).toEqual({ encoding: 'utf-8' });
+        expect(fs.readFile.mock.calls[0][2]).toBeInstanceOf(Function);
+
+        expect(themeBuilder).toHaveBeenCalled();
+        expect(saveThemeScssFile).not.toHaveBeenCalled();
+
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe('ThemeBuilder error');
+      });
+  });
 });

--- a/tests/unit/builder/getStylesAndSaveTheme.spec.js
+++ b/tests/unit/builder/getStylesAndSaveTheme.spec.js
@@ -8,14 +8,14 @@ const path = require('path');
 describe('Builder › getStylesAndSaveTheme.js', () => {
   beforeEach(() => {
     jest.resetModules();
-    fs.watch = jest.fn();
+    fs.watchFile = jest.fn();
     generateThemeFile.mockClear();
   });
 
   it('sets the yamlFile\'s basename to "_default.yaml" when no themeFile is provided', () => {
     return getStylesAndSaveTheme()
       .then(() => {
-        expect(fs.watch).not.toHaveBeenCalled();
+        expect(fs.watchFile).not.toHaveBeenCalled();
         expect(generateThemeFile).toHaveBeenCalled();
         expect(path.basename(generateThemeFile.mock.calls[0][0])).toBe('_default.yaml');
       });
@@ -24,7 +24,7 @@ describe('Builder › getStylesAndSaveTheme.js', () => {
   it('calls generateThemeFile and resolves without watching files (when watch = false)', () => {
     return getStylesAndSaveTheme('fake/yaml/file.yml', false)
       .then(() => {
-        expect(fs.watch).not.toHaveBeenCalled();
+        expect(fs.watchFile).not.toHaveBeenCalled();
         expect(generateThemeFile).toHaveBeenCalled();
         expect(generateThemeFile).toHaveBeenCalledWith('fake/yaml/file.yml');
       });
@@ -33,10 +33,9 @@ describe('Builder › getStylesAndSaveTheme.js', () => {
   it('calls generateThemeFile and watches the yaml file (when watch = true)', () => {
     return getStylesAndSaveTheme('fake/yaml/file.yml', true)
       .then(() => {
-        expect(fs.watch).toHaveBeenCalled();
-        expect(fs.watch.mock.calls[0][0]).toBe('fake/yaml/file.yml');
-        expect(fs.watch.mock.calls[0][1]).toEqual({ persistent: true });
-        expect(fs.watch.mock.calls[0][2]).toBeInstanceOf(Function);
+        expect(fs.watchFile).toHaveBeenCalled();
+        expect(fs.watchFile.mock.calls[0][0]).toBe('fake/yaml/file.yml');
+        expect(fs.watchFile.mock.calls[0][1]).toBeInstanceOf(Function);
 
         expect(generateThemeFile).toHaveBeenCalled();
         expect(generateThemeFile).toHaveBeenCalledWith('fake/yaml/file.yml');
@@ -44,14 +43,13 @@ describe('Builder › getStylesAndSaveTheme.js', () => {
   });
 
   it('calls generateThemeFile when executing the watcher\'s callback (when watch = true)', () => {
-    fs.watch.mockImplementation((filePath, opts, cb) => cb()); // Automatically yields
+    fs.watchFile.mockImplementation((filePath, cb) => cb()); // Automatically yields
 
     return getStylesAndSaveTheme('fake/yaml/file.yml', true)
       .then(() => {
-        expect(fs.watch).toHaveBeenCalled();
-        expect(fs.watch.mock.calls[0][0]).toBe('fake/yaml/file.yml');
-        expect(fs.watch.mock.calls[0][1]).toEqual({ persistent: true });
-        expect(fs.watch.mock.calls[0][2]).toBeInstanceOf(Function);
+        expect(fs.watchFile).toHaveBeenCalled();
+        expect(fs.watchFile.mock.calls[0][0]).toBe('fake/yaml/file.yml');
+        expect(fs.watchFile.mock.calls[0][1]).toBeInstanceOf(Function);
 
         expect(generateThemeFile).toHaveBeenCalledTimes(2);
         expect(generateThemeFile).toHaveBeenCalledWith('fake/yaml/file.yml');


### PR DESCRIPTION
# What does this PR do:

* Changes the `getStylesAndSaveTheme.js` to use the `fs.watchFile` instead of the `fs.watch`. This solves a problem of getting the `change` event being triggered more than once.

* Changes the `getStylesAndSaveTheme.js` to log a message whenever it detects changes and is able to rebuild the `theme.scss`.

* Changes the `getStylesAndSaveTheme.js` to log the error on the shell when an error happens on the watch callback.

* Changes the `generateThemeFile.js` to wrap the `themeBuilder` call in a `try..catch` rejecting the promise on error.

# Where should the reviewer start:
  - Diffs