### PR TITLE
Fixes size's prop definition

### DIFF
--- a/components/price/price.js
+++ b/components/price/price.js
@@ -126,7 +126,7 @@ Price.propTypes = {
   /**
    * Price's size
    */
-  size: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
+  size: PropTypes.oneOf(['s', 'm', 'l', 'xl']),
 
   /**
    * Currency symbol. Defines the currency symbol of the Price.


### PR DESCRIPTION
# What does this PR do:
Removes the _xs_ value from the `size`'s `propTypes` definition.

# Where should the reviewer start:
  - Diffs