### PR TITLE
Fixes issue #31 - Changes the builder to properly catch rejections and to output the errors on the webpack process

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ $ node_modules/.bin/travix-ui-kit -h
 
   Options:
 
-    -h, --help                 output usage information
-    -V, --version              output the version number
-    -c, --css-dir <directory>  Destination directory of the ui-kit.css
-    -j, --js-dir <directory>   Destination directory of the ui-kit.js
-    -t, --theme-file <path>    Path to a theme file to override default UI Kit styles
-    -w, --watch                Enables file-watcher functionality
+    -h, --help                       output usage information
+    -V, --version                    output the version number
+    -c, --css-dir <directory>        Destination directory of the ui-kit.css
+    -c, --environment <environment>  Environment in which to run the build
+    -j, --js-dir <directory>         Destination directory of the ui-kit.js
+    -t, --theme-file <path>          Path to a theme file to override default UI Kit styles
+    -w, --watch                      Enables file-watcher functionality
 ```
 
 For example, if we want to generate our UI Bundles, with the default styling, on `./js/` and `./css/` folders,

--- a/builder/builder.js
+++ b/builder/builder.js
@@ -2,10 +2,6 @@ const getStylesAndSaveTheme = require('./getStylesAndSaveTheme');
 const runWebpackAndCopyFilesToFinalDestination = require('./runWebpackAndCopyFilesToFinalDestination');
 const webpackConfig = require('./webpack.config');
 
-const webpackNodeEnv = {
-  'process.env.NODE_ENV': process.env.NODE_ENV || 'development',
-};
-
 /**
  * Triggers the build process.
  *
@@ -16,11 +12,13 @@ const webpackNodeEnv = {
  * @param {Boolean} watch      Flag to determine if it should run in 'watch' mode
  * @return {Promise}
  */
-module.exports = ({ cssDir, jsDir, themeFile, watch }) => getStylesAndSaveTheme(themeFile, watch)
-  .then(() => runWebpackAndCopyFilesToFinalDestination({
-    webpackConfig,
-    webpackNodeEnv,
-    cssDir,
-    jsDir,
-    watch,
-  }));
+module.exports = ({ cssDir, environment = 'development', jsDir, themeFile, watch }) => {
+  return getStylesAndSaveTheme(themeFile, watch)
+    .then(() => runWebpackAndCopyFilesToFinalDestination({
+      cssDir,
+      jsDir,
+      watch,
+      webpackConfig,
+      webpackNodeEnv: { 'process.env.NODE_ENV': environment },
+    }));
+};

--- a/builder/builder.js
+++ b/builder/builder.js
@@ -19,6 +19,6 @@ module.exports = ({ cssDir, environment, jsDir, themeFile, watch }) => {
       jsDir,
       watch,
       webpackConfig,
-      webpackNodeEnv: { 'process.env.NODE_ENV': environment },
+      webpackNodeEnv: { 'process.env.NODE_ENV': environment || 'development' },
     }));
 };

--- a/builder/builder.js
+++ b/builder/builder.js
@@ -12,7 +12,7 @@ const webpackConfig = require('./webpack.config');
  * @param {Boolean} watch      Flag to determine if it should run in 'watch' mode
  * @return {Promise}
  */
-module.exports = ({ cssDir, environment = 'development', jsDir, themeFile, watch }) => {
+module.exports = ({ cssDir, environment, jsDir, themeFile, watch }) => {
   return getStylesAndSaveTheme(themeFile, watch)
     .then(() => runWebpackAndCopyFilesToFinalDestination({
       cssDir,

--- a/builder/builder.js
+++ b/builder/builder.js
@@ -16,13 +16,11 @@ const webpackNodeEnv = {
  * @param {Boolean} watch      Flag to determine if it should run in 'watch' mode
  * @return {Promise}
  */
-module.exports = ({ cssDir, jsDir, themeFile, watch }) => {
-  return getStylesAndSaveTheme(themeFile, watch)
-    .then(runWebpackAndCopyFilesToFinalDestination({
-      webpackConfig,
-      webpackNodeEnv,
-      cssDir,
-      jsDir,
-      watch,
-    }));
-};
+module.exports = ({ cssDir, jsDir, themeFile, watch }) => getStylesAndSaveTheme(themeFile, watch)
+  .then(() => runWebpackAndCopyFilesToFinalDestination({
+    webpackConfig,
+    webpackNodeEnv,
+    cssDir,
+    jsDir,
+    watch,
+  }));

--- a/builder/index.js
+++ b/builder/index.js
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
-const program = require('commander');
-const pkg = require('../package.json');
 const builder = require('./builder');
+const pkg = require('../package.json');
+const program = require('commander');
 
 program
   .version(pkg.version)
   .option('-c, --css-dir <directory>', 'Destination directory of the ui-kit.css')
+  .option('-e, --environment <environment>', 'Environment in which to run the build', process.env.NODE_ENV)
   .option('-j, --js-dir <directory>', 'Destination directory of the ui-kit.js')
   .option('-t, --theme-file <path>', 'Path to a theme file to override default UI Kit styles')
   .option('-w, --watch', 'Enables file-watcher functionality', false);

--- a/builder/webpack.config.js
+++ b/builder/webpack.config.js
@@ -9,6 +9,7 @@ const outputDir = path.join(__dirname, '..', 'dist');
  * @type {Object}
  */
 module.exports = {
+  bail: true,
   entry: {
     dist: [
       '../components/index.scss',

--- a/components/button/button.js
+++ b/components/button/button.js
@@ -10,13 +10,9 @@ const { PropTypes } = React;
 function Button({ children, mods = [], size, href, onClick, type, variation, disabled, dataAttrs = {} }) {
   const restProps = getDataAttributes(dataAttrs);
 
-  if (size) {
-    mods.push(`size_${size}`);
-  }
-
-  if (variation) {
-    mods.push(`variation_${variation}`);
-  }
+  /** This props have default values */
+  mods.push(`size_${size}`);
+  mods.push(`variation_${variation}`);
 
   if (disabled) {
     mods.push(`disabled_true`);

--- a/components/spinner/spinner.js
+++ b/components/spinner/spinner.js
@@ -8,9 +8,7 @@ const { PropTypes } = React;
  * General Spinner component. Use when you need spinner
  */
 function Spinner({ mods = [], size }) {
-  if (size) {
-    mods.push(`size_${size}`);
-  }
+  mods.push(`size_${size}`);
 
   const className = getClassNamesWithMods('ui-spinner', mods);
 

--- a/tests/unit/builder/builder.spec.js
+++ b/tests/unit/builder/builder.spec.js
@@ -10,26 +10,28 @@ describe('Builder › builder.js', () => {
   it('should call the dependencies\' functions with the proper args', () => {
     const args = {
       cssDir: 'myCssDir',
+      environment: process.env.NODE_ENV,
       jsDir: 'myJsDir',
       themeFile: 'myThemeFile',
       watch: true,
     };
 
-    return builder(args)
-      .then(() => {
-        expect(getStylesAndSaveTheme).toHaveBeenCalled();
-        expect(getStylesAndSaveTheme).toHaveBeenCalledWith(args.themeFile, args.watch);
+    const result = builder(args);
 
-        expect(runWebpackAndCopyFilesToFinalDestination).toHaveBeenCalled();
-        expect(runWebpackAndCopyFilesToFinalDestination).toHaveBeenCalledWith({
-          cssDir: args.cssDir,
-          jsDir: args.jsDir,
-          watch: args.watch,
-          webpackConfig: webpackConfig,
-          webpackNodeEnv: {
-            'process.env.NODE_ENV': 'test', // When running jest, the env changes to 'test'
-          },
-        });
+    expect(result).toBeInstanceOf(Promise);
+
+    return result.then(() => {
+      expect(getStylesAndSaveTheme).toHaveBeenCalled();
+      expect(getStylesAndSaveTheme).toHaveBeenCalledWith(args.themeFile, args.watch);
+
+      expect(runWebpackAndCopyFilesToFinalDestination).toHaveBeenCalled();
+      expect(runWebpackAndCopyFilesToFinalDestination).toHaveBeenCalledWith({
+        cssDir: args.cssDir,
+        jsDir: args.jsDir,
+        watch: args.watch,
+        webpackConfig: webpackConfig,
+        webpackNodeEnv: { 'process.env.NODE_ENV': process.env.NODE_ENV },
       });
+    });
   });
 });

--- a/tests/unit/builder/builder.spec.js
+++ b/tests/unit/builder/builder.spec.js
@@ -34,4 +34,31 @@ describe('Builder › builder.js', () => {
       });
     });
   });
+  it('should pass on the environment if different from the process.env.NODE_ENV', () => {
+    const args = {
+      cssDir: 'myCssDir',
+      environment: 'myOwnEnv',
+      jsDir: 'myJsDir',
+      themeFile: 'myThemeFile',
+      watch: true,
+    };
+
+    const result = builder(args);
+
+    expect(result).toBeInstanceOf(Promise);
+
+    return result.then(() => {
+      expect(getStylesAndSaveTheme).toHaveBeenCalled();
+      expect(getStylesAndSaveTheme).toHaveBeenCalledWith(args.themeFile, args.watch);
+
+      expect(runWebpackAndCopyFilesToFinalDestination).toHaveBeenCalled();
+      expect(runWebpackAndCopyFilesToFinalDestination).toHaveBeenCalledWith({
+        cssDir: args.cssDir,
+        jsDir: args.jsDir,
+        watch: args.watch,
+        webpackConfig: webpackConfig,
+        webpackNodeEnv: { 'process.env.NODE_ENV': 'myOwnEnv' },
+      });
+    });
+  });
 });

--- a/tests/unit/builder/builder.spec.js
+++ b/tests/unit/builder/builder.spec.js
@@ -34,6 +34,7 @@ describe('Builder › builder.js', () => {
       });
     });
   });
+
   it('should pass on the environment if different from the process.env.NODE_ENV', () => {
     const args = {
       cssDir: 'myCssDir',
@@ -58,6 +59,33 @@ describe('Builder › builder.js', () => {
         watch: args.watch,
         webpackConfig: webpackConfig,
         webpackNodeEnv: { 'process.env.NODE_ENV': 'myOwnEnv' },
+      });
+    });
+  });
+
+  it('should default the environment to "development" when not provided', () => {
+    const args = {
+      cssDir: 'myCssDir',
+      jsDir: 'myJsDir',
+      themeFile: 'myThemeFile',
+      watch: true,
+    };
+
+    const result = builder(args);
+
+    expect(result).toBeInstanceOf(Promise);
+
+    return result.then(() => {
+      expect(getStylesAndSaveTheme).toHaveBeenCalled();
+      expect(getStylesAndSaveTheme).toHaveBeenCalledWith(args.themeFile, args.watch);
+
+      expect(runWebpackAndCopyFilesToFinalDestination).toHaveBeenCalled();
+      expect(runWebpackAndCopyFilesToFinalDestination).toHaveBeenCalledWith({
+        cssDir: args.cssDir,
+        jsDir: args.jsDir,
+        watch: args.watch,
+        webpackConfig: webpackConfig,
+        webpackNodeEnv: { 'process.env.NODE_ENV': 'development' },
       });
     });
   });

--- a/tests/unit/builder/index.spec.js
+++ b/tests/unit/builder/index.spec.js
@@ -20,10 +20,15 @@ describe('Builder › generateThemeFile.js', () => {
     expect(commander.version).toHaveBeenCalled();
     expect(commander.version).toHaveBeenCalledWith(pkg.version);
 
-    expect(commander.option).toHaveBeenCalledTimes(4);
+    expect(commander.option).toHaveBeenCalledTimes(5);
     expect(commander.option).toHaveBeenCalledWith(
       '-c, --css-dir <directory>',
       'Destination directory of the ui-kit.css'
+    );
+    expect(commander.option).toHaveBeenCalledWith(
+      '-e, --environment <environment>',
+      'Environment in which to run the build',
+      process.env.NODE_ENV
     );
     expect(commander.option).toHaveBeenCalledWith(
       '-j, --js-dir <directory>',

--- a/tests/unit/button/__snapshots__/button.spec.js.snap
+++ b/tests/unit/button/__snapshots__/button.spec.js.snap
@@ -35,3 +35,14 @@ exports[`Button #render() should return base class with mods for strings as clas
   Extra small
 </button>
 `;
+
+exports[`Button #render() should return base class with mods for strings as class and string as mods without data-attrs 1`] = `
+<button
+  className="ui-button ui-button_size_m ui-button_variation_default"
+  disabled={false}
+  onClick={[Function]}
+  type="button"
+>
+  Extra small
+</button>
+`;

--- a/tests/unit/button/button.spec.js
+++ b/tests/unit/button/button.spec.js
@@ -48,5 +48,13 @@ describe('Button', () => {
 
       expect(shallowToJson(wrapper)).toMatchSnapshot();
     });
+
+    it('should return base class with mods for strings as class and string as mods without data-attrs', () => {
+      const wrapper = shallow(
+        <Button onClick={onClickSpy} type="button">Extra small</Button>
+      );
+
+      expect(shallowToJson(wrapper)).toMatchSnapshot();
+    });
   });
 });

--- a/tests/unit/helpers/helpers.spec.js
+++ b/tests/unit/helpers/helpers.spec.js
@@ -9,6 +9,9 @@ describe('helpers', () => {
     it('#2 should return class with mods for strings as array of classes and array as mods', () => {
       expect(getClassNamesWithMods(['test', 'test2'], ['first', 'second'])).toBe('test test2 test_first test_second');
     });
+    it('#3 should return only an array with the classes provided in the first arg', () => {
+      expect(getClassNamesWithMods(['test', 'test2'])).toBe('test test2');
+    });
   });
 
   describe('#getDataAttributes()', () => {


### PR DESCRIPTION
# What does this PR do:

* Increases the coverage by removing certain conditionals that verified if a property is set when it they have a default value.

* Changes the `builder.js` to return the `Promise` instead of executing it.

* Adds the `bail` property to the `webpack.config.js` to force it to fail immediately so that we get the exact error instead of the last one.

<img width="1672" alt="screen shot 2017-03-09 at 11 05 04" src="https://cloud.githubusercontent.com/assets/1002056/23745404/4db0c5be-04b8-11e7-8248-38f6a6d4c284.png">


# Where should the reviewer start:
  - Diffs

# Unit and/or functional tests:
All tests are passing.