### PR TITLE
fix for price component

### DIFF
--- a/components/price/price.js
+++ b/components/price/price.js
@@ -35,7 +35,7 @@ export function addThousandsSeparator(value, thousandsSeparator) {
  * @param {Number} decimalsPrecision  Number of decimals to be allowed.
  * @return {String}                   The value with a proper precision.
  */
-export function ensureDecimalPrecision(value, decimalsPrecision = 2) {
+export function ensureDecimalPrecision(value = '', decimalsPrecision = 2) {
   if (value.length > decimalsPrecision) {
     return value.substr(0, decimalsPrecision);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "travix-ui-kit",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "description": "Travix UI kit",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "travix-ui-kit",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Travix UI kit",
   "main": "lib/index.js",
   "scripts": {

--- a/tests/unit/price/__snapshots__/price.spec.js.snap
+++ b/tests/unit/price/__snapshots__/price.spec.js.snap
@@ -53,6 +53,32 @@ exports[`Price #render() should render only the amount of decimals defined in th
 </div>
 `;
 
+exports[`Price #render() should render with decimals when value is integer 1`] = `
+<div
+  className="ui-price ui-price_size_l"
+>
+  <div
+    className="ui-price__value-delimiter"
+  >
+    <div
+      className="ui-price__currency ui-price__currency_left"
+    >
+      €
+    </div>
+    <div
+      className="ui-price__integers"
+    >
+      50,153
+    </div>
+    <div
+      className="ui-price__decimals"
+    >
+      .00
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Price #render() should render with ui-price_size_xl class 1`] = `
 <div
   className="ui-price ui-price_size_xl"

--- a/tests/unit/price/price.spec.js
+++ b/tests/unit/price/price.spec.js
@@ -28,6 +28,7 @@ describe('Price', () => {
       expect(ensureDecimalPrecision('5')).toEqual('50');
       expect(ensureDecimalPrecision('5', 3)).toEqual('500');
       expect(ensureDecimalPrecision('', 3)).toEqual('000');
+      expect(ensureDecimalPrecision(undefined, 3)).toEqual('000');
     });
   });
 
@@ -127,6 +128,14 @@ describe('Price', () => {
           size="xl"
           value={50153.30}
         />
+      );
+
+      expect(shallowToJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should render with decimals when value is integer', () => {
+      const wrapper = shallow(
+        <Price value={50153} />
       );
 
       expect(shallowToJson(wrapper)).toMatchSnapshot();


### PR DESCRIPTION
# What does this PR do:
When an integer number is provided to the Price component, the `ensureDecimalPrecision` function does not handle the _undefined_ (attempts to convert it to string).

This PR changes the `ensureDecimalPrecision` to have a default value on the `value` attribute to be empty string, fixing the issue.

# Where should the reviewer start:
  - Diffs, specially the file `price.js`.

# Unit and/or functional tests:
Tests covering the issue added.