### PR TITLE
Removes dependencies related to current date on Calendar's unit tests

### DIFF
--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -64,11 +64,10 @@ function processProps(props) {
   }
 
   /** If the renderDate is not between any of the minLimit and/or maxDate, we need to redefine it. */
-  if (
-    (minLimit && (renderDate.getMonth() < minLimit.getMonth())) ||
-    (maxLimit && (renderDate.getMonth() > maxLimit.getMonth()))
-  ) {
+  if (minLimit && (renderDate.getMonth() < minLimit.getMonth())) {
     renderDate.setMonth(minLimit.getMonth());
+  } else if (maxLimit && (renderDate.getMonth() > maxLimit.getMonth())) {
+    renderDate.setMonth(maxLimit.getMonth());
   }
 
   return {

--- a/tests/unit/calendar/calendar.normal.spec.js
+++ b/tests/unit/calendar/calendar.normal.spec.js
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import React from 'react';
 import Calendar from '../../../components/calendar/calendar';
 import CalendarWrapper from './calendarWrapper.mock';
-import { normalizeDate } from '../../../components/_helpers';
+import { leftPad, normalizeDate } from '../../../components/_helpers';
 
 describe('Calendar (normal mode)', () => {
   describe('#render()', () => {
@@ -45,8 +45,16 @@ describe('Calendar (normal mode)', () => {
 
     it('should set maxLimit, with a given "maxDate" attribute', () => {
       const maxDate = '2017-03-20';
-      const todayDate = normalizeDate(new Date());
       const maxDateObject = normalizeDate(new Date(maxDate), 23, 59, 59, 999);
+
+      const todayDate = new Date();
+      const renderDateYYYYMMDD = [
+        maxDateObject.getFullYear(),
+        leftPad(maxDateObject.getMonth() + 1),
+        leftPad(todayDate.getDate()),
+      ].join('-');
+
+      const renderDate = normalizeDate(new Date(renderDateYYYYMMDD));
 
       const wrapper = mount(
         <Calendar maxDate={maxDate} />
@@ -59,7 +67,7 @@ describe('Calendar (normal mode)', () => {
       expect(wrapper.state()).toEqual({
         maxLimit: maxDateObject,
         minLimit: null,
-        renderDate: todayDate,
+        renderDate,
         selectedDates: [null, null],
       });
     });
@@ -86,17 +94,18 @@ describe('Calendar (normal mode)', () => {
     });
 
     it('should reset selectedDates, when at least one of the initialDates are outside min/max limit', () => {
-      const initialDates = ['2017-03-23', '2017-03-29'];
-      const initialDatesObjects = initialDates.map(dateStr => normalizeDate(new Date(dateStr)));
+      const initialDates = ['2017-02-23', '2017-03-29'];
       const maxDate = '2017-03-25';
       const maxDateObject = normalizeDate(new Date(maxDate), 23, 59, 59, 999);
       const minDate = '2017-03-20';
       const minDateObject = normalizeDate(new Date(minDate));
 
-
       const wrapper = mount(
         <Calendar initialDates={initialDates} maxDate={maxDate} minDate={minDate} />
       );
+
+      const expectedRenderDate = normalizeDate(new Date(initialDates[0]));
+      expectedRenderDate.setMonth(minDateObject.getMonth());
 
       expect(wrapper.props()).toEqual({
         initialDates,
@@ -107,7 +116,28 @@ describe('Calendar (normal mode)', () => {
       expect(wrapper.state()).toEqual({
         maxLimit: maxDateObject,
         minLimit: minDateObject,
-        renderDate: initialDatesObjects[0],
+        renderDate: expectedRenderDate,
+        selectedDates: [null, null],
+      });
+
+
+      const initialDates2 = ['2017-04-21', '2017-04-24'];
+      const expectedRenderDate2 = normalizeDate(new Date(initialDates2[0]));
+      expectedRenderDate2.setMonth(maxDateObject.getMonth());
+      const wrapper2 = mount(
+        <Calendar initialDates={initialDates2} maxDate={maxDate} minDate={minDate} />
+      );
+
+      expect(wrapper2.props()).toEqual({
+        initialDates: initialDates2,
+        maxDate,
+        minDate,
+        selectionType: 'normal',
+      });
+      expect(wrapper2.state()).toEqual({
+        maxLimit: maxDateObject,
+        minLimit: minDateObject,
+        renderDate: expectedRenderDate2,
         selectedDates: [null, null],
       });
     });

--- a/tests/unit/calendar/calendar.range.spec.js
+++ b/tests/unit/calendar/calendar.range.spec.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import React from 'react';
 import Calendar from '../../../components/calendar/calendar';
-import { normalizeDate } from '../../../components/_helpers';
+import { leftPad, normalizeDate } from '../../../components/_helpers';
 
 describe('Calendar (range mode)', () => {
   describe('#render()', () => {
@@ -60,26 +60,45 @@ describe('Calendar (range mode)', () => {
         selectedDates: [null, null],
       });
 
-      const expectedStartDate = normalizeDate(new Date('2017-03-25'));
+      const dayBeforeStart = [
+        todayDate.getFullYear(),
+        leftPad(todayDate.getMonth() + 1),
+        '22',
+      ].join('-');
 
-      const startRangeOption = wrapper.find('[data-date="2017-03-25"]');
+      const dayBetweenStartAndEnd = [
+        todayDate.getFullYear(),
+        leftPad(todayDate.getMonth() + 1),
+        '25',
+      ].join('-');
+
+      const expectedStart = [
+        todayDate.getFullYear(),
+        leftPad(todayDate.getMonth() + 1),
+        '23',
+      ].join('-');
+
+      const expectedEnd = [
+        todayDate.getFullYear(),
+        leftPad(todayDate.getMonth() + 1),
+        '27',
+      ].join('-');
+
+      const expectedStartDate = normalizeDate(new Date(expectedStart));
+      const expectedEndDate = normalizeDate(new Date(expectedEnd));
+
+      const startRangeOption = wrapper.find(`[data-date="${expectedStart}"]`);
       startRangeOption.simulate('click');
       expect(startRangeOption.props().className.includes('ui-calendar-days-option_selected-start')).toEqual(true);
       expect(wrapper.state().minLimit).toEqual(expectedStartDate);
       expect(wrapper.state().selectedDates[0]).toEqual(expectedStartDate);
-      expect(wrapper.find('[data-date="2017-03-24"]').props().disabled).toEqual(true);
-
-      const expectedEndDate = new Date('2017-03-29');
-      expectedEndDate.setHours(0);
-      expectedEndDate.setMinutes(0);
-      expectedEndDate.setSeconds(0);
-      expectedEndDate.setMilliseconds(0);
+      expect(wrapper.find(`[data-date="${dayBeforeStart}"]`).props().disabled).toEqual(true);
 
       // Selects the end date on the 2nd click
-      const endRangeOption = wrapper.find('[data-date="2017-03-29"]');
+      const endRangeOption = wrapper.find(`[data-date="${expectedEnd}"]`);
       endRangeOption.simulate('click');
 
-      const betweenRangeOption = wrapper.find('[data-date="2017-03-28"]');
+      const betweenRangeOption = wrapper.find(`[data-date="${dayBetweenStartAndEnd}"]`);
 
       expect(endRangeOption.props().className.includes('ui-calendar-days-option_selected-end')).toEqual(true);
       expect(wrapper.state().selectedDates[1]).toEqual(expectedEndDate);
@@ -92,20 +111,28 @@ describe('Calendar (range mode)', () => {
     });
 
     it('should render the selection as normal (not range) when start and end date are the same', () => {
-      const expectedEndDate = normalizeDate(new Date('2017-03-25'));
-      const expectedStartDate = normalizeDate(new Date('2017-03-25'));
+      const todayDate = normalizeDate(new Date());
+      const expectedStart = [
+        todayDate.getFullYear(),
+        leftPad(todayDate.getMonth() + 1),
+        '25',
+      ].join('-');
+
+
+      const expectedEndDate = normalizeDate(new Date(expectedStart));
+      const expectedStartDate = normalizeDate(new Date(expectedStart));
       const wrapper = mount(
         <Calendar selectionType="range" />
       );
 
-      const startRangeOption = wrapper.find('[data-date="2017-03-25"]');
+      const startRangeOption = wrapper.find(`[data-date="${expectedStart}"]`);
       startRangeOption.simulate('click');
       expect(startRangeOption.props().className.includes('ui-calendar-days-option_selected-start')).toEqual(true);
       expect(wrapper.state().minLimit).toEqual(expectedStartDate);
       expect(wrapper.state().selectedDates[0]).toEqual(expectedStartDate);
 
       // Selects the end date on the 2nd click
-      const endRangeOption = wrapper.find('[data-date="2017-03-25"]');
+      const endRangeOption = wrapper.find(`[data-date="${expectedStart}"]`);
       endRangeOption.simulate('click');
 
       expect(endRangeOption.props().className.includes('ui-calendar-days-option_selected')).toEqual(true);
@@ -114,8 +141,19 @@ describe('Calendar (range mode)', () => {
     });
 
     it('should put the minLimit back to the one passed on props, when resetting it', () => {
-      const expectedEndDate = normalizeDate(new Date('2017-03-25'));
-      const expectedStartDate = normalizeDate(new Date('2017-03-25'));
+      const todayDate = normalizeDate(new Date());
+      const differentDay = [
+        todayDate.getFullYear(),
+        leftPad(todayDate.getMonth() + 1),
+        '26',
+      ].join('-');
+      const expectedStart = [
+        todayDate.getFullYear(),
+        leftPad(todayDate.getMonth() + 1),
+        '25',
+      ].join('-');
+      const expectedEndDate = normalizeDate(new Date(expectedStart));
+      const expectedStartDate = normalizeDate(new Date(expectedStart));
       const minDate = '2017-03-05';
       const expectedInitialMinLimit = normalizeDate(new Date(minDate));
 
@@ -125,14 +163,14 @@ describe('Calendar (range mode)', () => {
 
       expect(wrapper.state().minLimit).toEqual(expectedInitialMinLimit);
 
-      const startRangeOption = wrapper.find('[data-date="2017-03-25"]');
+      const startRangeOption = wrapper.find(`[data-date="${expectedStart}"]`);
       startRangeOption.simulate('click');
       expect(startRangeOption.props().className.includes('ui-calendar-days-option_selected-start')).toEqual(true);
       expect(wrapper.state().minLimit).toEqual(expectedStartDate);
       expect(wrapper.state().selectedDates[0]).toEqual(expectedStartDate);
 
       // Selects the end date on the 2nd click
-      const endRangeOption = wrapper.find('[data-date="2017-03-25"]');
+      const endRangeOption = wrapper.find(`[data-date="${expectedStart}"]`);
       endRangeOption.simulate('click');
 
       expect(endRangeOption.props().className.includes('ui-calendar-days-option_selected')).toEqual(true);
@@ -140,7 +178,7 @@ describe('Calendar (range mode)', () => {
       expect(wrapper.state().selectedDates[1]).toEqual(expectedEndDate);
 
       // And resets the dates with the 3rd click
-      wrapper.find('[data-date="2017-03-26"]').simulate('click');
+      wrapper.find(`[data-date="${differentDay}"]`).simulate('click');
       expect(wrapper.state().minLimit).toEqual(expectedInitialMinLimit);
       expect(wrapper.state().selectedDates).toEqual([null, null]);
     });


### PR DESCRIPTION
# What does this PR do:

  - Resets `renderDate` to `maxLimit`'s month when `renderDate` is bigger than `maxLimit`.
  - Removes dependencies related to current date on `Calendar`'s unit tests

## Before
![screen shot 2017-04-03 at 11 24 37](https://cloud.githubusercontent.com/assets/1002056/24603230/3e52437a-1860-11e7-90f1-b126512f18da.png)

## After
![screen shot 2017-04-03 at 11 26 35](https://cloud.githubusercontent.com/assets/1002056/24603281/6bb99890-1860-11e7-909f-3e255fb5eb47.png)


# Where should the reviewer start:
  - Diffs

# Unit and/or functional tests:
Fixes calendar's tests.