### PR TITLE
added scripts to Makefile for publishing travix-ui-kit to github pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ styleguide/
 themes/theme.scss
 .DS_Store
 wallaby.js
+_site

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ release:
 	npm version $(VERSION)
 	npm publish
 	git push --follow-tags
+	make publish-site
 
 changelog:
 	git checkout master
@@ -23,3 +24,26 @@ push-changelog:
 	git add CHANGELOG.md
 	git commit -m 'changelog updated.'
 	git push origin master
+
+prepare-site:
+	npm run styleguide-build
+	rm -rf ./_site
+	mkdir _site
+	cp -r ./styleguide/ ./_site/
+	cp ./dist/ui-bundle.css ./_site/build/ui-bundle.css
+	sed -i.bak 's/\/ui\-bundle\.css/build\/ui\-bundle\.css/g' _site/index.html
+	rm _site/index.html.bak
+	cp .gitignore ./_site/.gitignore
+
+publish-site-only:
+	(cd ./_site && git init)
+	(cd ./_site && git commit --allow-empty -m 'update site')
+	(cd ./_site && git checkout -b gh-pages)
+	(cd ./_site && touch .nojekyll)
+	(cd ./_site && git add .)
+	(cd ./_site && git commit -am 'update site')
+	(cd ./_site && git push git@github.com:Travix-International/travix-ui-kit.git gh-pages --force)
+
+publish-site:
+	make prepare-site
+	make publish-site-only

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 Travix UI Components' repository.
 
 ## UI-Kit
+Take a look at: https://travix-international.github.io/travix-ui-kit/
+
 ### How to install and setup
 - `npm i travix-ui-kit -S` install as a dependency
 


### PR DESCRIPTION
## What does this PR do:
* adds possibility to publish travix-ui-kit on GitHub Pages
* scripts are added to the `Makefile`, so with every release on npm via Makefile we are releasing new version to the documentation page