### PR TITLE
Button restProps and non-mutating mods

### DIFF
--- a/components/autoComplete/autoComplete.js
+++ b/components/autoComplete/autoComplete.js
@@ -285,11 +285,11 @@ class AutoComplete extends Component {
       dataAttrs = {},
       disabled,
       label,
-      mods = [],
       name,
       placeholder,
       ...otherProps
     } = this.props;
+    const mods = this.props.mods ? this.props.mods.slice() : [];
 
     this.state.open && mods.push('open');
     const className = getClassNamesWithMods('ui-autocomplete', mods);

--- a/components/autoComplete/autoCompleteItem.js
+++ b/components/autoComplete/autoCompleteItem.js
@@ -28,12 +28,12 @@ class AutoCompleteItem extends Component {
     const {
       children,
       dataAttrs = {},
-      mods = [],
       onClick,
       isActive,
       isTitle,
       ...otherProps
     } = this.props;
+    const mods = this.props.mods ? this.props.mods.slice() : [];
 
     isTitle && mods.push('title');
     isActive && mods.push('active');

--- a/components/button/button.js
+++ b/components/button/button.js
@@ -7,9 +7,19 @@ const { PropTypes } = React;
 /**
  * General Button component. Use when you need button or a link that looks like button
  */
-function Button({ children, mods = [], size, href, onClick, type, variation, disabled, dataAttrs = {} }) {
+function Button(props) {
+  const {
+    children,
+    size,
+    href,
+    onClick,
+    type,
+    variation,
+    disabled,
+    dataAttrs = {},
+  } = props;
   const restProps = getDataAttributes(dataAttrs);
-
+  const mods = props.mods ? props.mods.slice() : [];
   /** This props have default values */
   mods.push(`size_${size}`);
   mods.push(`variation_${variation}`);
@@ -43,7 +53,15 @@ function Button({ children, mods = [], size, href, onClick, type, variation, dis
   }
 
   return (
-    <button className={className} disabled={disabled} onClick={onClick} type="button">{children}</button>
+    <button
+      className={className}
+      disabled={disabled}
+      onClick={onClick}
+      type="button"
+      {...restProps}
+    >
+      {children}
+    </button>
   );
 }
 

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -203,7 +203,8 @@ export default class Calendar extends Component {
   }
 
   render() {
-    const { dataAttrs = {}, isDaySelectableFn, locale, mods = [], navButtons, selectionType } = this.props;
+    const { dataAttrs = {}, isDaySelectableFn, locale, navButtons, selectionType } = this.props;
+    const mods = this.props.mods ? this.props.mods.slice() : [];
     const { maxLimit, minLimit, renderDate, selectedDates } = this.state;
 
     const restProps = getDataAttributes(dataAttrs);

--- a/components/checkbox/checkbox.js
+++ b/components/checkbox/checkbox.js
@@ -4,14 +4,15 @@ import { getClassNamesWithMods } from '../_helpers';
 /**
  * Checkbox component.
  */
-function Checkbox({
-  checked,
-  children,
-  disabled,
-  mods = [],
-  name,
-  onChange,
-}) {
+function Checkbox(props) {
+  const {
+    checked,
+    children,
+    disabled,
+    name,
+    onChange,
+  } = props;
+  const mods = props.mods ? props.mods.slice() : [];
   disabled && mods.push('is-disabled');
   const className = getClassNamesWithMods('ui-checkbox', mods);
 

--- a/components/input/input.js
+++ b/components/input/input.js
@@ -65,11 +65,11 @@ class Input extends Component {
     const {
       dataAttrs = {},
       disabled,
-      mods = [],
       multiline,
       value,
       ...otherProps
     } = this.props;
+    const mods = this.props.mods ? this.props.mods.slice() : [];
 
     this.state.isFocused && mods.push('focused');
     const className = getClassNamesWithMods('ui-input', mods);

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -5,7 +5,10 @@ import { getClassNamesWithMods } from '../_helpers';
 /**
  * General List component. Use when you need to display array of elements
  */
-function List({ items, hideBullets, mods = [], align }) {
+function List(props) {
+  const { items, hideBullets, align } = props;
+  const mods = props.mods ? props.mods.slice() : [];
+
   mods.push(`align_${align}`);
 
   if (hideBullets) {

--- a/components/modal/modal.js
+++ b/components/modal/modal.js
@@ -139,8 +139,9 @@ class Modal extends Component {
   }
 
   render() {
-    const { active, fullscreen, children, mods = [] } = this.props;
+    const { active, fullscreen, children } = this.props;
     const { isOpen } = this.state;
+    const mods = this.props.mods ? this.props.mods.slice() : [];
 
     if (active) {
       mods.push('active');

--- a/components/price/price.js
+++ b/components/price/price.js
@@ -39,19 +39,21 @@ export function ensureDecimalPrecision(value = '', decimalsPrecision = 2) {
 /**
  * Price component
  */
-function Price({
-  dataAttrs = {},
-  decimalsPrecision,
-  decimalsSeparator,
-  mods = [],
-  showDecimals,
-  size,
-  symbol,
-  symbolPosition,
-  thousandsSeparator,
-  underlined,
-  value,
-}) {
+function Price(props) {
+  const {
+    dataAttrs = {},
+    decimalsPrecision,
+    decimalsSeparator,
+    showDecimals,
+    size,
+    symbol,
+    symbolPosition,
+    thousandsSeparator,
+    underlined,
+    value,
+  } = props;
+  const mods = props.mods ? props.mods.slice() : [];
+
   const rootClass = 'ui-price';
   const [intValue, decValue] = value.toString().split('.');
 

--- a/components/radioButton/radioButton.js
+++ b/components/radioButton/radioButton.js
@@ -6,16 +6,18 @@ import { getClassNamesWithMods, getDataAttributes } from '../_helpers';
 /**
  * RadioButton component
  */
-function RadioButton({
-  checked,
-  children,
-  dataAttrs = {},
-  disabled,
-  id,
-  mods = [],
-  name,
-  onChange }) {
+function RadioButton(props) {
+  const {
+    checked,
+    children,
+    dataAttrs = {},
+    disabled,
+    id,
+    name,
+    onChange,
+  } = props;
   const restProps = getDataAttributes(dataAttrs);
+  const mods = props.mods ? props.mods.slice() : [];
 
   if (disabled) {
     mods.push('disabled');

--- a/components/spinner/spinner.js
+++ b/components/spinner/spinner.js
@@ -7,7 +7,10 @@ const { PropTypes } = React;
 /**
  * General Spinner component. Use when you need spinner
  */
-function Spinner({ mods = [], size }) {
+function Spinner(props) {
+  const { size } = props;
+  const mods = props.mods ? props.mods.slice() : [];
+
   mods.push(`size_${size}`);
 
   const className = getClassNamesWithMods('ui-spinner', mods);

--- a/tests/unit/autoComplete/__snapshots__/autoComplete.render.spec.js.snap
+++ b/tests/unit/autoComplete/__snapshots__/autoComplete.render.spec.js.snap
@@ -1,5 +1,63 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AutoComplete #render() should copy mods 1`] = `
+<div
+  className="ui-autocomplete ui-autocomplete_test"
+  highlighted={false}
+  mods={
+    Array [
+      "test",
+    ]
+  }
+>
+  <Input
+    aria-activedescendant="ui-autocomplete-item-autocomplete-0"
+    aria-autocomplete="list"
+    aria-expanded={false}
+    aria-haspopup={false}
+    aria-labelledby=""
+    aria-owns="ui-autocomplete-list-autocomplete"
+    autoComplete="off"
+    disabled={false}
+    id="ui-autocomplete-input-autocomplete"
+    multiline={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    role="combobox"
+  />
+  <Input
+    disabled={false}
+    hidden={true}
+    multiline={false}
+    name="autocomplete"
+  />
+  <div
+    className="ui-autocomplete__popunder"
+  >
+    <ul
+      aria-expanded={false}
+      className="ui-autocomplete__popunder-list"
+      id="ui-autocomplete-list-autocomplete"
+      role="listbox"
+    >
+      <AutoCompleteItem
+        id="ui-autocomplete-item-autocomplete-0"
+        index={0}
+        isActive={true}
+        isTitle={false}
+        onClick={[Function]}
+        onMouseDown={[Function]}
+        value="value"
+      >
+        item
+      </AutoCompleteItem>
+    </ul>
+  </div>
+</div>
+`;
+
 exports[`AutoComplete #render() should not render item child if it not "AutoCompleteItem" 1`] = `
 <div
   className="ui-autocomplete"

--- a/tests/unit/autoComplete/autoComplete.render.spec.js
+++ b/tests/unit/autoComplete/autoComplete.render.spec.js
@@ -25,6 +25,26 @@ describe('AutoComplete', () => {
       expect(shallowToJson(wrapper)).toMatchSnapshot();
     });
 
+    it('should copy mods', () => {
+      const mods = ['test'];
+      const wrapper = shallow(
+        <AutoComplete
+          mods={mods}
+          name="autocomplete"
+        >
+          <AutoCompleteItem
+            value="value"
+          >
+            item
+          </AutoCompleteItem>
+        </AutoComplete>
+      );
+
+      expect(mods.length).toEqual(1);
+      expect(mods[0]).toEqual('test');
+      expect(shallowToJson(wrapper)).toMatchSnapshot();
+    });
+
     it('should render correct open autocomplete component', () => {
       const component = shallow(
         <AutoComplete

--- a/tests/unit/autoCompleteItem/__snapshots__/autoCompleteItem.render.spec.js.snap
+++ b/tests/unit/autoCompleteItem/__snapshots__/autoCompleteItem.render.spec.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AutoCompleteItem #render() should not modify mods 1`] = `
+<li
+  className="ui-autocomplete-item ui-autocomplete-item_test"
+  mods={
+    Array [
+      "test",
+    ]
+  }
+  onClick={[Function]}
+  role="option"
+  tabIndex="-1"
+  value="value"
+>
+  item
+</li>
+`;
+
 exports[`AutoCompleteItem #render() should render autocomplete item with active mode 1`] = `
 <li
   className="ui-autocomplete-item ui-autocomplete-item_active"

--- a/tests/unit/autoCompleteItem/autoCompleteItem.render.spec.js
+++ b/tests/unit/autoCompleteItem/autoCompleteItem.render.spec.js
@@ -20,6 +20,21 @@ describe('AutoCompleteItem', () => {
       expect(shallowToJson(wrapper)).toMatchSnapshot();
     });
 
+    it('should not modify mods', () => {
+      const mods = ['test'];
+      const wrapper = shallow(
+        <AutoCompleteItem
+          mods={mods}
+          value="value"
+        >
+          item
+        </AutoCompleteItem>
+      );
+      expect(mods.length).toEqual(1);
+      expect(mods[0]).toEqual('test');
+      expect(shallowToJson(wrapper)).toMatchSnapshot();
+    });
+
     it('should render autocomplete item with title mode', () => {
       const wrapper = shallow(
         <AutoCompleteItem

--- a/tests/unit/button/__snapshots__/button.spec.js.snap
+++ b/tests/unit/button/__snapshots__/button.spec.js.snap
@@ -1,20 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Button #render() should return base class with mods for strings as class and string as mods 1`] = `
+exports[`Button #render() should not modify mods 1`] = `
+<button
+  className="ui-button ui-button_test ui-button_size_m ui-button_variation_default"
+  disabled={false}
+  onClick={[Function]}
+  type="button"
+/>
+`;
+
+exports[`Button #render() should render disabled link 1`] = `
 <a
   className="ui-button ui-button_size_xs ui-button_variation_default ui-button_disabled_true"
-  data-gtm="id"
   href="http://google.com"
 >
   Extra small
 </a>
 `;
 
-exports[`Button #render() should return base class with mods for strings as class and string as mods 2`] = `<noscript />`;
+exports[`Button #render() should render gtm data attribute 1`] = `
+<button
+  className="ui-button ui-button_size_m ui-button_variation_default"
+  data-gtm="id"
+  disabled={false}
+  onClick={[Function]}
+  type="button"
+>
+  Extra small
+</button>
+`;
 
-exports[`Button #render() should return base class with mods for strings as class and string as mods 3`] = `<noscript />`;
+exports[`Button #render() should return base class with mods for strings as class and string as mods #1 1`] = `<noscript />`;
 
-exports[`Button #render() should return base class with mods for strings as class and string as mods 4`] = `
+exports[`Button #render() should return base class with mods for strings as class and string as mods #2 1`] = `
 <button
   className="ui-button ui-button_size_xs ui-button_variation_default"
   data-gtm="id"
@@ -25,7 +43,7 @@ exports[`Button #render() should return base class with mods for strings as clas
 </button>
 `;
 
-exports[`Button #render() should return base class with mods for strings as class and string as mods 5`] = `
+exports[`Button #render() should return base class with mods for strings as class and string as mods #3 1`] = `
 <button
   className="ui-button ui-button_size_xs ui-button_variation_default"
   disabled={false}
@@ -46,3 +64,5 @@ exports[`Button #render() should return base class with mods for strings as clas
   Extra small
 </button>
 `;
+
+exports[`Button #render() should return noscript if no onClick provided 1`] = `<noscript />`;

--- a/tests/unit/button/button.spec.js
+++ b/tests/unit/button/button.spec.js
@@ -9,31 +9,45 @@ describe('Button', () => {
     const shallowToJson = enzymeToJson.shallowToJson;
     const onClickSpy = () => {};
 
-    it('should return base class with mods for strings as class and string as mods', () => {
+    it('should render disabled link', () => {
       const wrapper = shallow(
-        <Button dataAttrs={{ gtm: 'id' }} disabled href="http://google.com" size="xs" type="link">Extra small</Button>
+        <Button disabled href="http://google.com" size="xs" type="link">Extra small</Button>
       );
 
       expect(shallowToJson(wrapper)).toMatchSnapshot();
     });
 
-    it('should return base class with mods for strings as class and string as mods', () => {
+    it('should return base class with mods for strings as class and string as mods #1', () => {
       const wrapper = shallow(
-        <Button dataAttrs={{ gtm: 'id' }} disabled size="xs" type="link">Extra small</Button>
+        <Button disabled size="xs" type="link">Extra small</Button>
       );
 
       expect(shallowToJson(wrapper)).toMatchSnapshot();
     });
 
-    it('should return base class with mods for strings as class and string as mods', () => {
+    it('should return noscript if no onClick provided', () => {
       const wrapper = shallow(
-        <Button dataAttrs={{ gtm: 'id' }} size="xs">Extra small</Button>
+        <Button>Extra small</Button>
       );
 
       expect(shallowToJson(wrapper)).toMatchSnapshot();
     });
 
-    it('should return base class with mods for strings as class and string as mods', () => {
+    it('should not modify mods', () => {
+      const mods = ['test'];
+      const wrapper = shallow(
+        <Button
+          mods={mods}
+          onClick={onClickSpy}
+        />
+      );
+
+      expect(mods.length).toEqual(1);
+      expect(mods[0]).toEqual('test');
+      expect(shallowToJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should return base class with mods for strings as class and string as mods #2', () => {
       const wrapper = shallow(
         <Button dataAttrs={{ gtm: 'id' }} size="xs" type="submit">Extra small</Button>
       );
@@ -41,9 +55,17 @@ describe('Button', () => {
       expect(shallowToJson(wrapper)).toMatchSnapshot();
     });
 
-    it('should return base class with mods for strings as class and string as mods', () => {
+    it('should return base class with mods for strings as class and string as mods #3', () => {
       const wrapper = shallow(
-        <Button dataAttrs={{ gtm: 'id' }} onClick={onClickSpy} size="xs" type="button">Extra small</Button>
+        <Button onClick={onClickSpy} size="xs" type="button">Extra small</Button>
+      );
+
+      expect(shallowToJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should render gtm data attribute', () => {
+      const wrapper = shallow(
+        <Button dataAttrs={{ gtm: 'id' }} onClick={onClickSpy}>Extra small</Button>
       );
 
       expect(shallowToJson(wrapper)).toMatchSnapshot();

--- a/tests/unit/calendar/__snapshots__/calendar.normal.spec.js.snap
+++ b/tests/unit/calendar/__snapshots__/calendar.normal.spec.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Calendar (normal mode) #render() should not mutate props 1`] = `
+<div
+  className="ui-calendar ui-calendar_test"
+>
+  <Days
+    maxDate={null}
+    minDate={null}
+    onNavNextMonth={[Function]}
+    onNavPreviousMonth={[Function]}
+    onSelectDay={[Function]}
+    renderDate={2017-05-05T00:00:00.000Z}
+    selectedDates={
+      Array [
+        null,
+        null,
+      ]
+    }
+    selectionType="normal"
+  />
+</div>
+`;

--- a/tests/unit/calendar/calendar.normal.spec.js
+++ b/tests/unit/calendar/calendar.normal.spec.js
@@ -1,4 +1,5 @@
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
+import { shallowToJson } from 'enzyme-to-json';
 import React from 'react';
 import Calendar from '../../../components/calendar/calendar';
 import CalendarWrapper from './calendarWrapper.mock';
@@ -21,6 +22,18 @@ describe('Calendar (normal mode)', () => {
         renderDate: todayDate,
         selectedDates: [null, null],
       });
+    });
+
+    it('should not mutate props', () => {
+      const mods = ['test'];
+      const wrapper = shallow(
+        <Calendar
+          mods={mods}
+        />
+      );
+      expect(shallowToJson(wrapper)).toMatchSnapshot();
+      expect(mods.length).toEqual(1);
+      expect(mods[0]).toEqual('test');
     });
 
     it('should set renderDate and not minLimit, with a given "initalDates" attribute', () => {

--- a/tests/unit/checkbox/__snapshots__/checkbox.spec.js.snap
+++ b/tests/unit/checkbox/__snapshots__/checkbox.spec.js.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Checkbox #render() should not modify mods 1`] = `
+<label
+  className="ui-checkbox ui-checkbox_test"
+  htmlFor=""
+>
+  <input
+    aria-checked={false}
+    checked={false}
+    disabled={false}
+    id=""
+    role="radio"
+    type="checkbox"
+  />
+  <span
+    className="ui-checkbox__text"
+  />
+</label>
+`;
+
 exports[`Checkbox #render() should render checkbox 1`] = `
 <label
   className="ui-checkbox"

--- a/tests/unit/checkbox/checkbox.spec.js
+++ b/tests/unit/checkbox/checkbox.spec.js
@@ -21,6 +21,19 @@ describe('Checkbox', () => {
       expect(shallowToJson(wrapper)).toMatchSnapshot();
     });
 
+    it('should not modify mods', () => {
+      const mods = ['test'];
+      const wrapper = shallow(
+        <Checkbox
+          mods={mods}
+        />
+      );
+
+      expect(mods.length).toEqual(1);
+      expect(mods[0]).toEqual('test');
+      expect(shallowToJson(wrapper)).toMatchSnapshot();
+    });
+
     it('should render checked checkbox', () => {
       const wrapper = shallow(
         <Checkbox

--- a/tests/unit/input/__snapshots__/input.render.spec.js.snap
+++ b/tests/unit/input/__snapshots__/input.render.spec.js.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Input #render() should not modify mods 1`] = `
+<input
+  className="ui-input ui-input_test"
+  disabled={false}
+  mods={
+    Array [
+      "test",
+    ]
+  }
+  onBlur={[Function]}
+  onChange={[Function]}
+  onFocus={[Function]}
+/>
+`;
+
 exports[`Input #render() should render correct input 1`] = `
 <input
   className="ui-input"

--- a/tests/unit/input/input.render.spec.js
+++ b/tests/unit/input/input.render.spec.js
@@ -21,6 +21,19 @@ describe('Input', () => {
       expect(shallowToJson(wrapper)).toMatchSnapshot();
     });
 
+    it('should not modify mods', () => {
+      const mods = ['test'];
+      const wrapper = shallow(
+        <Input
+          mods={mods}
+        />
+      );
+
+      expect(mods.length).toEqual(1);
+      expect(mods[0]).toEqual('test');
+      expect(shallowToJson(wrapper)).toMatchSnapshot();
+    });
+
     it('should render multiline input', () => {
       const wrapper = shallow(
         <Input

--- a/tests/unit/list/__snapshots__/list.spec.js.snap
+++ b/tests/unit/list/__snapshots__/list.spec.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`List #render() should not modify mods 1`] = `
+<ul
+  className="ui-list ui-list_test ui-list_align_vertical"
+>
+  <li
+    className="ui-list__item"
+  >
+    London
+  </li>
+  <li
+    className="ui-list__item"
+  >
+    Amsterdam
+  </li>
+  <li
+    className="ui-list__item"
+  >
+    Madrid
+  </li>
+</ul>
+`;
+
 exports[`List #render() should return base class with mods for strings as class and string as mods 1`] = `
 <ul
   className="ui-list ui-list_align_vertical"

--- a/tests/unit/list/list.spec.js
+++ b/tests/unit/list/list.spec.js
@@ -8,6 +8,21 @@ describe('List', () => {
     const shallow = enzyme.shallow;
     const shallowToJson = enzymeToJson.shallowToJson;
 
+    it('should not modify mods', () => {
+      const mods = ['test'];
+      const wrapper = shallow(
+        <List
+          align="vertical"
+          items={['London', 'Amsterdam', 'Madrid']}
+          mods={mods}
+        />
+      );
+
+      expect(mods.length).toEqual(1);
+      expect(mods[0]).toEqual('test');
+      expect(shallowToJson(wrapper)).toMatchSnapshot();
+    });
+
     it('should return base class with mods for strings as class and string as mods', () => {
       const wrapper = shallow(
         <List align="vertical" items={['London', 'Amsterdam', 'Madrid']} />

--- a/tests/unit/radioButton/__snapshots__/radioButton.spec.js.snap
+++ b/tests/unit/radioButton/__snapshots__/radioButton.spec.js.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Radio Button #render() should not modify mods 1`] = `
+<div
+  className="ui-radio ui-radio_test ui-radio_disabled"
+>
+  <input
+    checked={false}
+    className="ui-radio__input-radio"
+    disabled={true}
+    id="disabledRadio"
+    onChange={[Function]}
+    type="radio"
+  />
+  <label
+    aria-checked={false}
+    className="ui-radio__label"
+    htmlFor="disabledRadio"
+    role="radio"
+  >
+    Disabled radio button
+  </label>
+</div>
+`;
+
 exports[`Radio Button #render() should render checked radio button 1`] = `
 <div
   className="ui-radio"

--- a/tests/unit/radioButton/radioButton.spec.js
+++ b/tests/unit/radioButton/radioButton.spec.js
@@ -9,6 +9,19 @@ describe('Radio Button', () => {
     const shallowToJson = enzymeToJson.shallowToJson;
     const onChange = () => {};
 
+    it('should not modify mods', () => {
+      const mods = ['test'];
+      const wrapper = shallow(
+        <RadioButton disabled id="disabledRadio" mods={mods} onChange={onChange}>
+          Disabled radio button
+        </RadioButton>
+      );
+
+      expect(mods.length).toEqual(1);
+      expect(mods[0]).toEqual('test');
+      expect(shallowToJson(wrapper)).toMatchSnapshot();
+    });
+
     it('should render disabled radio button', () => {
       const wrapper = shallow(
         <RadioButton disabled id="disabledRadio" onChange={onChange}>

--- a/tests/unit/spinner/__snapshots__/spinner.spec.js.snap
+++ b/tests/unit/spinner/__snapshots__/spinner.spec.js.snap
@@ -1,5 +1,106 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Spinner #render() should not modify mods 1`] = `
+<div
+  className="ui-spinner ui-spinner_test ui-spinner_size_xs"
+>
+  <svg
+    styles="enable-background:new 0 0 80 80;"
+    version="1.1"
+    viewBox="0 0 80 80"
+    x="0px"
+    xlinkHref="http://www.w3.org/1999/xlink"
+    xmlSpace="preserve"
+    xmlns="http://www.w3.org/2000/svg"
+    y="0px"
+  >
+    <g>
+      <g>
+        <circle
+          clipRule="evenodd"
+          cx="40"
+          cy="40"
+          fillRule="evenodd"
+          r="34.3"
+        />
+        <path
+          className="ui-spinner_darker"
+          clipRule="evenodd"
+          d="M39.9,33.1c0.5-5.4-1.5-10.4-5.2-14.9c6.1-2.1,7.6-1.5,8.6,3.8c0.5,2.9,0.4,6,0.1,9c-0.1,0.9-0.3,1.8-0.7,2.7c-0.8-0.3-1.8-0.6-2.7-0.6H39.9z"
+          fillRule="evenodd"
+        />
+        <path
+          className="ui-spinner_dark"
+          clipRule="evenodd"
+          d="M46.6,41.9c5.3,2,10.6,2.1,16-0.3c0.8,5.6-0.3,7-5.4,6.9c-4.6,0-8.5-1.6-12-4.1C45.9,43.7,46.3,42.8,46.6,41.9z"
+          fillRule="evenodd"
+        />
+        <path
+          className="ui-spinner_dark"
+          clipRule="evenodd"
+          d="M44.3,45.4c3.1,4.5,7.2,7.7,13.2,8.9c-3.2,5.1-5.1,5.5-9.2,2.1c-3.2-2.6-5.3-5.9-6.5-9.8C42.7,46.4,43.5,46,44.3,45.4z"
+          fillRule="evenodd"
+        />
+        <path
+          className="ui-spinner_dark"
+          clipRule="evenodd"
+          d="M40.1,46.9c-0.1,5.6,1.3,10.4,5.3,14.5c-5.6,2.6-7.2,2-8.6-3.3c-0.5-1.8-0.8-3.7-0.6-5.6c0.2-2,0.6-4.1,1.1-6.2c0.8,0.3,1.7,0.5,2.7,0.5H40.1z"
+          fillRule="evenodd"
+        />
+        <path
+          className="ui-spinner_dark"
+          clipRule="evenodd"
+          d="M36,45.5c-3.5,4.3-5,9.2-4.7,14.8c-5.7-1.2-6.8-2.7-4.9-7.3c1.1-2.5,2.6-4.8,4.4-6.8c0.9-1,2-1.9,3.3-2.8C34.6,44.3,35.2,45,36,45.5z"
+          fillRule="evenodd"
+        />
+        <path
+          className="ui-spinner_dark"
+          clipRule="evenodd"
+          d="M33.5,42.1c-5.6,1.5-9.8,4.5-12.8,9.5c-4-4.2-3.9-6.4,0.6-9.1c1.6-1,3.4-1.9,5.2-2.2c2.2-0.4,4.4-0.6,6.6-0.8l0,0.5C33.1,40.7,33.2,41.5,33.5,42.1z"
+          fillRule="evenodd"
+        />
+        <path
+          className="ui-spinner_darker"
+          clipRule="evenodd"
+          d="M33.5,37.9c-3.7-1.5-7.1-1.4-16,0c-1-4.9,0.3-6.5,5-6.6c4.7,0,8.8,1.6,12.4,4.1C34.2,36.2,33.8,37,33.5,37.9z"
+          fillRule="evenodd"
+        />
+        <path
+          className="ui-spinner_darker"
+          clipRule="evenodd"
+          d="M35.8,34.6c-3-4.7-7.3-7.8-13.2-9c3.4-5.2,5.2-5.5,9.5-1.9c3.2,2.6,5.2,5.9,6.5,9.6C37.5,33.5,36.6,34,35.8,34.6z"
+          fillRule="evenodd"
+        />
+        <path
+          className="ui-spinner_dark"
+          clipRule="evenodd"
+          d="M48,34.8c-0.5,0.7-1.4,1.1-2.1,1.6c-0.5-0.8-1.1-1.5-1.8-2c3.5-4.4,5.2-9.2,4.6-14.9c5.7,0.8,7.1,2.7,5.1,7.1C52.3,29.6,50,32.2,48,34.8z"
+          fillRule="evenodd"
+        />
+        <path
+          className="ui-spinner_dark"
+          clipRule="evenodd"
+          d="M46.9,40c0-0.8-0.1-1.5-0.4-2.2c5.8-1.6,10-4.7,13.1-9.6c4.4,6.1,3.2,6.4-1.3,9.5c-1.5,1-3.3,1.7-5,2c-2.1,0.4-4.2,0.6-6.4,0.8L46.9,40z"
+          fillRule="evenodd"
+        />
+      </g>
+      <circle
+        className="ui-spinner_lighter"
+        clipRule="evenodd"
+        cx="40"
+        cy="40"
+        fillRule="evenodd"
+        r="36"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeMiterlimit="10"
+        strokeWidth="8"
+      />
+    </g>
+  </svg>
+</div>
+`;
+
 exports[`Spinner #render() should return base class with mods for strings as class and string as mods 1`] = `
 <div
   className="ui-spinner ui-spinner_size_xs"

--- a/tests/unit/spinner/spinner.spec.js
+++ b/tests/unit/spinner/spinner.spec.js
@@ -8,6 +8,17 @@ describe('Spinner', () => {
     const shallow = enzyme.shallow;
     const shallowToJson = enzymeToJson.shallowToJson;
 
+    it('should not modify mods', () => {
+      const mods = ['test'];
+      const wrapper = shallow(
+        <Spinner mods={mods} size="xs">Extra small</Spinner>
+      );
+
+      expect(mods.length).toEqual(1);
+      expect(mods[0]).toEqual('test');
+      expect(shallowToJson(wrapper)).toMatchSnapshot();
+    });
+
     it('should return base class with mods for strings as class and string as mods', () => {
       const wrapper = shallow(
         <Spinner size="xs">Extra small</Spinner>


### PR DESCRIPTION
## What
- Button component `restProps` for data attributes for simple button fix
- Don't mutate props.mods (fix for #77 ): slice mods if provided or just use a new array

## Where
- Diff

## Tests
- 100% covereage
- added new snapshots
- updated old ones