### PR TITLE
Fixes the config for Webpack 2 on the styleguide.config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "jest-cli": "^19.0.1",
     "jest-serializer-enzyme": "^1.0.0",
     "react-addons-test-utils": "^0.14.8",
-    "react-styleguidist": "^5.0.0",
+    "react-styleguidist": "~5.1.10",
     "webpack-hot-middleware": "^2.15.0"
   },
   "greenkeeper": {

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -9,13 +9,13 @@ module.exports = {
   },
   webpackConfig: {
     module: {
-      loaders: [
+      rules: [
         {
           test: /\.js?$/,
           include: __dirname + '/components',
-          loader: 'babel'
-        }
-      ]
-    }
-  }
+          use: 'babel-loader',
+        },
+      ],
+    },
+  },
 };


### PR DESCRIPTION
# What does this PR do:

* Fixes the `styleguide.config.js` to work with Webpack 2.
* Locks the version of `react-styleguidist` to v5.1.10, since >= v5.2.0 have issues with our JSDoc ( check https://github.com/styleguidist/react-styleguidist/releases/tag/v5.2.0 ).

# Where should the reviewer start:

* Diffs
* Build the style guide.