### PR TITLE
Allow Modal window to be active by default

### DIFF
--- a/components/modal/modal.js
+++ b/components/modal/modal.js
@@ -16,6 +16,9 @@ class Modal extends Component {
     if (this.props.closeOnEsc) {
       global.window.document.addEventListener('keydown', this.handleKeyDown);
     }
+    if (this.props.active) {
+      this.open();
+    }
   }
 
   componentWillReceiveProps(newProps) {

--- a/tests/unit/button/__snapshots__/button.spec.js.snap
+++ b/tests/unit/button/__snapshots__/button.spec.js.snap
@@ -6,7 +6,9 @@ exports[`Button #render() should not modify mods 1`] = `
   disabled={false}
   onClick={[Function]}
   type="button"
-/>
+>
+  Button
+</button>
 `;
 
 exports[`Button #render() should render disabled link 1`] = `

--- a/tests/unit/button/button.spec.js
+++ b/tests/unit/button/button.spec.js
@@ -39,7 +39,9 @@ describe('Button', () => {
         <Button
           mods={mods}
           onClick={onClickSpy}
-        />
+        >
+          Button
+        </Button>
       );
 
       expect(mods.length).toEqual(1);

--- a/tests/unit/modal/modal.close.spec.js
+++ b/tests/unit/modal/modal.close.spec.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import Modal from '../../../components/modal/modal';
 
 describe('Modal: open', () => {
-  const requestAnimationFrame = global.window.document.requestAnimationFrame;
+  const requestAnimationFrame = global.window.requestAnimationFrame;
 
   jest.useFakeTimers();
 

--- a/tests/unit/modal/modal.componentDidMount.spec.js
+++ b/tests/unit/modal/modal.componentDidMount.spec.js
@@ -36,7 +36,7 @@ describe('Modal: handleOverlayClick', () => {
     expect(global.window.document.addEventListener).not.toBeCalled();
   });
 
-  it('should open if the active prop is set', () => {
+  it('should open the modal window if the active prop is set by default', () => {
     Modal.prototype.open = jest.fn();
     mount(<Modal active />);
     expect(Modal.prototype.open).toBeCalled();

--- a/tests/unit/modal/modal.componentDidMount.spec.js
+++ b/tests/unit/modal/modal.componentDidMount.spec.js
@@ -17,7 +17,6 @@ describe('Modal: handleOverlayClick', () => {
     const onClose = jest.fn();
     mount(
       <Modal
-        active
         onClose={onClose}
       >
         Modal Content
@@ -29,12 +28,17 @@ describe('Modal: handleOverlayClick', () => {
   it('should not add "keydown" event listener if modal is not closable on ESC', () => {
     mount(
       <Modal
-        active
         closeOnEsc={false}
       >
         Modal Content
       </Modal>
     );
     expect(global.window.document.addEventListener).not.toBeCalled();
+  });
+
+  it('should open if the active prop is set', () => {
+    Modal.prototype.open = jest.fn();
+    mount(<Modal active />);
+    expect(Modal.prototype.open).toBeCalled();
   });
 });

--- a/tests/unit/modal/modal.componentWillUnmount.spec.js
+++ b/tests/unit/modal/modal.componentWillUnmount.spec.js
@@ -15,9 +15,7 @@ describe('Modal: componentWillUnmount', () => {
 
   it('should remove "keydown" listener before unmount', () => {
     const wrapper = mount(
-      <Modal
-        active
-      >
+      <Modal>
         Modal Content
       </Modal>
     );
@@ -28,7 +26,6 @@ describe('Modal: componentWillUnmount', () => {
   it('should remove "keydown" listener before unmount', () => {
     const wrapper = mount(
       <Modal
-        active
         closeOnEsc={false}
       >
         Modal Content

--- a/tests/unit/modal/modal.open.spec.js
+++ b/tests/unit/modal/modal.open.spec.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import Modal from '../../../components/modal/modal';
 
 describe('Modal: open', () => {
-  const requestAnimationFrame = global.window.document.requestAnimationFrame;
+  const requestAnimationFrame = global.window.requestAnimationFrame;
   jest.useFakeTimers();
 
   beforeEach(() => {


### PR DESCRIPTION
The current implementation of the Modal component doesn't allow it to be open by default (it only opens after a prop change). This PR allows a `<Modal active />` to display as expected.

I've also included some small miscellaneous fixes, let me know if there's no problem merging with this one:

- Switched references from `window.document.requestAnimationFrame` (no such property exists on `document`) to `window.requestAnimationFrame`.
- Updated the Button spec file to always pass required props (removes the big bold red warnings when running tests)

Fixes #103 