### PR TITLE
Change SlidingPanel to use the refs

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -7,6 +7,7 @@ import Checkbox from './checkbox/checkbox';
 import Collapse from './collapse/collapse';
 import CollapseItem from './collapse/collapseItem';
 import DropDown from './dropDown/dropDown';
+import Global from './global/global';
 import Input from './input/input';
 import List from './list/list';
 import Modal from './modal/modal';
@@ -26,6 +27,7 @@ export default {
   Collapse,
   CollapseItem,
   DropDown,
+  Global,
   Input,
   List,
   Modal,

--- a/components/slidingPanel/slidingPanel.js
+++ b/components/slidingPanel/slidingPanel.js
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes } from 'react';
-import { findDOMNode } from 'react-dom';
 import { getClassNamesWithMods, getDataAttributes } from '../_helpers';
 
 export default class SlidingPanel extends Component {

--- a/components/slidingPanel/slidingPanel.js
+++ b/components/slidingPanel/slidingPanel.js
@@ -73,8 +73,7 @@ export default class SlidingPanel extends Component {
 
     this.panel.addEventListener('transitionend', this.handleTransitionEnd);
 
-    const rootNode = findDOMNode(this);
-    const closeButton = rootNode.querySelector('[rel="close"]');
+    const closeButton = this.panel.querySelector('[rel="close"]');
     if (closeButton) {
       closeButton.addEventListener('click', this.handleClose);
     }

--- a/components/slidingPanel/slidingPanel.js
+++ b/components/slidingPanel/slidingPanel.js
@@ -79,6 +79,10 @@ export default class SlidingPanel extends Component {
     }
   }
 
+  componentWillUnmount() {
+    this.panel.removeEventListener('transitionend', this.handleTransitionEnd);
+  }
+
   /**
    * Handles the click in the overlay.
    *

--- a/components/slidingPanel/slidingPanel.js
+++ b/components/slidingPanel/slidingPanel.js
@@ -104,13 +104,8 @@ export default class SlidingPanel extends Component {
    * @param {SyntheticEvent} e Click event trapped in the overlay element
    */
   handleClose() {
-    const { onClose } = this.props;
 
-    this.setState({ isActive: false }, () => {
-      if (onClose) {
-        onClose();
-      }
-    });
+    this.setState({ isActive: false });
   }
 
   /**
@@ -133,8 +128,13 @@ export default class SlidingPanel extends Component {
   }
 
   handleTransitionEnd(e) {
+    const { onClose } = this.props;
     if (e.propertyName === 'transform') {
-      this.setState({ isOverlayHidden: !this.state.isActive });
+      this.setState({ isOverlayHidden: !this.state.isActive }, () => {
+        if (this.state.isOverlayHidden && onClose) {
+          onClose();
+        }
+      });
     }
   }
 

--- a/components/slidingPanel/slidingPanel.js
+++ b/components/slidingPanel/slidingPanel.js
@@ -73,14 +73,17 @@ export default class SlidingPanel extends Component {
 
     this.panel.addEventListener('transitionend', this.handleTransitionEnd);
 
-    const closeButton = this.panel.querySelector('[rel="close"]');
-    if (closeButton) {
-      closeButton.addEventListener('click', this.handleClose);
+    this.closeButton = this.panel.querySelector('[rel="close"]');
+    if (this.closeButton) {
+      this.closeButton.addEventListener('click', this.handleClose);
     }
   }
 
   componentWillUnmount() {
     this.panel.removeEventListener('transitionend', this.handleTransitionEnd);
+    if (this.closeButton) {
+      this.closeButton.removeEventListener('click', this.handleClose);
+    }
   }
 
   /**

--- a/components/slidingPanel/slidingPanel.js
+++ b/components/slidingPanel/slidingPanel.js
@@ -104,7 +104,6 @@ export default class SlidingPanel extends Component {
    * @param {SyntheticEvent} e Click event trapped in the overlay element
    */
   handleClose() {
-
     this.setState({ isActive: false });
   }
 

--- a/tests/unit/slidingPanel/slidingPanel.spec.js
+++ b/tests/unit/slidingPanel/slidingPanel.spec.js
@@ -41,8 +41,6 @@ describe('SlidingPanel', () => {
       renderTree.instance().handleTransitionEnd({ propertyName: 'transform' });
       jest.runAllTimers();
 
-      jest.runAllTimers();
-
       expect(renderTree).toMatchSnapshot();
       expect(overlayElement.hasClass('ui-sliding-panel-overlay_hidden')).toEqual(true);
       expect(panelElement.hasClass('ui-sliding-panel_active')).toEqual(false);

--- a/tests/unit/slidingPanel/slidingPanel.spec.js
+++ b/tests/unit/slidingPanel/slidingPanel.spec.js
@@ -196,6 +196,8 @@ describe('SlidingPanel', () => {
       instance.handleTransitionEnd({ propertyName: 'fakeProp' });
 
       expect(instance.setState.mock.calls.length).toEqual(0);
+
+      renderTree.unmount();
     });
   });
 });

--- a/tests/unit/slidingPanel/slidingPanel.spec.js
+++ b/tests/unit/slidingPanel/slidingPanel.spec.js
@@ -84,6 +84,8 @@ describe('SlidingPanel', () => {
       overlayElement.simulate('click');
 
       jest.runAllTimers();
+      renderTree.instance().handleTransitionEnd({ propertyName: 'transform' });
+
       expect(onCloseMock.mock.calls.length).toEqual(1);
     });
 


### PR DESCRIPTION
# What does this PR do:
* Adds usage of refs to remove usage of `findDOMNode`.

# Where should the reviewer start:
  - Diffs

# Unit and/or functional tests:
Adds `renderTree.unmount()` to pass via `componentWillUnmount()`.