### PR TITLE
Adds public API Key for Google Maps to the styleguide's HTML

### DIFF
--- a/components/googleMap/googleMap.md
+++ b/components/googleMap/googleMap.md
@@ -127,7 +127,6 @@ Map:
         </Checkbox>
       </div>
       <GoogleMap
-        apiKey=""
         points={state.enableCustomMarker ? state.points : undefined}
         center={state.enableCustomMarker ? state.center : undefined}
         google={window.google}

--- a/styleguide.html
+++ b/styleguide.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="/ui-bundle.css" data-cssvars />
     <link rel="stylesheet" href="/theme.css" />
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.find,String.prototype.repeat,Array.prototype.keys"></script>
-    <script src="https://maps.googleapis.com/maps/api/js?libraries=places,visualization&v=3.27"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?libraries=places,visualization&v=3.27&key=AIzaSyAqvSFBj-lPSA8BsEbSoqU7dzRlQxPUf8I"></script>
     <script>
       (function () {
         'use strict';


### PR DESCRIPTION
# What does this PR do:

* Adds the public API Key for Google Maps to work to the styleguide's HTML. This key is restricted to specific domains, so cannot be used on non-travix domains ;-)

* Also removed the `apiKey` attribute on the `googleMap.md` since it's not used.

# Where should the reviewer start:
  - Diffs