### PR TITLE
Change slidingPanel close button to use 'data-rel' attr instead of 'rel'

### DIFF
--- a/components/slidingPanel/slidingPanel.js
+++ b/components/slidingPanel/slidingPanel.js
@@ -79,7 +79,7 @@ export default class SlidingPanel extends Component {
 
     this.panel.addEventListener('transitionend', this.handleTransitionEnd);
 
-    this.closeButtons = this.panel.querySelectorAll('[rel="close"]');
+    this.closeButtons = this.panel.querySelectorAll('[data-rel="close"]');
     this.closeButtons.forEach(b => b.addEventListener('click', this.handleClose));
   }
 

--- a/components/slidingPanel/slidingPanel.md
+++ b/components/slidingPanel/slidingPanel.md
@@ -12,6 +12,6 @@ Basic Sliding Panel:
         This is an example<br/>
         Of how simple it is to use<br/>
         Our sliding panel.<br/><br/>
-        <button rel="close">Close</button>
+        <button data-rel="close">Close</button>
       </SlidingPanel>
     </div>

--- a/components/slidingPanel/slidingPanelHeader.js
+++ b/components/slidingPanel/slidingPanelHeader.js
@@ -13,7 +13,7 @@ const SlidingPanelHeader = ({ title }) => {
       </h3>
       <button
         className="ui-sliding-panel-header__close-button"
-        rel="close"
+        data-rel="close"
       >
         &#215;
       </button>

--- a/tests/unit/slidingPanel/__snapshots__/slidingPanel.spec.js.snap
+++ b/tests/unit/slidingPanel/__snapshots__/slidingPanel.spec.js.snap
@@ -44,7 +44,7 @@ exports[`SlidingPanel #render() closes the panel when active prop changes to fal
 </SlidingPanel>
 `;
 
-exports[`SlidingPanel #render() enables [rel="close"] element provided on the children, that closes the overlay 1`] = `
+exports[`SlidingPanel #render() enables [data-rel="close"] element provided on the children, that closes the overlay 1`] = `
 <SlidingPanel
   active={true}
   closeOnOverlayClick={false}
@@ -60,7 +60,7 @@ exports[`SlidingPanel #render() enables [rel="close"] element provided on the ch
         className="ui-sliding-panel__content"
       >
         <button
-          rel="close"
+          data-rel="close"
         >
           Test
         </button>
@@ -70,7 +70,7 @@ exports[`SlidingPanel #render() enables [rel="close"] element provided on the ch
 </SlidingPanel>
 `;
 
-exports[`SlidingPanel #render() enables [rel="close"] element provided on the children, that closes the overlay 2`] = `
+exports[`SlidingPanel #render() enables [data-rel="close"] element provided on the children, that closes the overlay 2`] = `
 <SlidingPanel
   active={true}
   closeOnOverlayClick={false}
@@ -86,7 +86,7 @@ exports[`SlidingPanel #render() enables [rel="close"] element provided on the ch
         className="ui-sliding-panel__content"
       >
         <button
-          rel="close"
+          data-rel="close"
         >
           Test
         </button>
@@ -257,7 +257,7 @@ exports[`SlidingPanel #render() render header if title prop is passed 1`] = `
           </h3>
           <button
             className="ui-sliding-panel-header__close-button"
-            rel="close"
+            data-rel="close"
           >
             ×
           </button>

--- a/tests/unit/slidingPanel/__snapshots__/slidingPanelHeader.spec.js.snap
+++ b/tests/unit/slidingPanel/__snapshots__/slidingPanelHeader.spec.js.snap
@@ -20,7 +20,7 @@ exports[`SlidingPanel #render() render with title 1`] = `
     </h3>
     <button
       className="ui-sliding-panel-header__close-button"
-      rel="close"
+      data-rel="close"
     >
       ×
     </button>

--- a/tests/unit/slidingPanel/slidingPanel.spec.js
+++ b/tests/unit/slidingPanel/slidingPanel.spec.js
@@ -101,11 +101,11 @@ describe('SlidingPanel', () => {
       expect(onCloseMock.mock.calls.length).toEqual(1);
     });
 
-    it('enables [rel="close"] element provided on the children, that closes the overlay', () => {
+    it('enables [data-rel="close"] element provided on the children, that closes the overlay', () => {
       document.body.insertAdjacentHTML('afterbegin', '<div id="root"></div>');
       const renderTree = mount(
         <SlidingPanel active closeOnOverlayClick={false}>
-          <button rel="close">Test</button>
+          <button data-rel="close">Test</button>
         </SlidingPanel>
       , { attachTo: document.body.querySelector('#root') });
       const overlayElement = renderTree.find('.ui-sliding-panel-overlay');
@@ -113,7 +113,7 @@ describe('SlidingPanel', () => {
 
       jest.runAllTimers();
 
-      const closeButtonElement = document.querySelector('.ui-sliding-panel_active [rel="close"]');
+      const closeButtonElement = document.querySelector('.ui-sliding-panel_active [data-rel="close"]');
 
       expect(renderTree).toMatchSnapshot();
       expect(overlayElement.hasClass('ui-sliding-panel-overlay_hidden')).toEqual(false);


### PR DESCRIPTION
## WHAT DOES THIS PR DO: ##

* Changed `rel` attribute in close button to `data-rel` to be able to make custom close button with `<Button dataAttrs={({ rel: 'close' })} />` component.

## WHERE SHOULD THE REVIEWER START: ##

* Diff

## UNIT TESTS: ##

* Adapted to pass 100%