### PR TITLE
Change Button's onClick prop to be optional

### DIFF
--- a/components/button/button.js
+++ b/components/button/button.js
@@ -46,11 +46,6 @@ function Button(props) {
     );
   }
 
-  if (!onClick) {
-    console.warn('Missing onClick'); // eslint-disable-line no-console
-    return <noscript />;
-  }
-
   return (
     <button
       className={className}

--- a/tests/unit/button/__snapshots__/button.spec.js.snap
+++ b/tests/unit/button/__snapshots__/button.spec.js.snap
@@ -66,5 +66,3 @@ exports[`Button #render() should return base class with mods for strings as clas
   Extra small
 </button>
 `;
-
-exports[`Button #render() should return noscript if no onClick provided 1`] = `<noscript />`;

--- a/tests/unit/button/button.spec.js
+++ b/tests/unit/button/button.spec.js
@@ -25,14 +25,6 @@ describe('Button', () => {
       expect(shallowToJson(wrapper)).toMatchSnapshot();
     });
 
-    it('should return noscript if no onClick provided', () => {
-      const wrapper = shallow(
-        <Button>Extra small</Button>
-      );
-
-      expect(shallowToJson(wrapper)).toMatchSnapshot();
-    });
-
     it('should not modify mods', () => {
       const mods = ['test'];
       const wrapper = shallow(


### PR DESCRIPTION
## WHAT DOES THIS PR DO: ##

* Makes `onClick` prop of `Button` component is optional and resolves issue #72 

## WHERE SHOULD THE REVIEWER START: ##

* Diff

## UNIT TESTS: ##

* One test is removed and the snapshot is updated. Coverage is 100%.