### PR TITLE
Change dependencies type

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,10 @@
     }
   ],
   "dependencies": {
-    "react-select": "^1.0.0-rc.5"
+    "extract-text-webpack-plugin": "~2.1.0",
+    "react-select": "^1.0.0-rc.5",
+    "sass-loader": "~6.0.4",
+    "webpack": "~2.5.1"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.1",
@@ -68,7 +71,6 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-react": "^6.10.2",
     "eslint": "^3.14.0",
-    "extract-text-webpack-plugin": "~2.1.0",
     "fs-extra": "^3.0.1",
     "jest-cli": "^19.0.0",
     "jest-serializer-enzyme": "^1.0.0",
@@ -80,11 +82,9 @@
     "react-dom": "^0.14.8",
     "react-styleguidist": "~5.1.10",
     "react": "^0.14.8",
-    "sass-loader": "~6.0.4",
     "style-loader": "~0.18.2",
     "theme-builder": "~0.5.0",
-    "webpack-hot-middleware": "^2.15.0",
-    "webpack": "~2.5.1"
+    "webpack-hot-middleware": "^2.15.0"
   },
   "greenkeeper": {
     "ignore": [


### PR DESCRIPTION
In case when it is necessary to use `builder` like an external projects build tool, `extract-text-webpack-plugin`, `sass-loader`, `webpack` need to be installed (because `build` requires them). devDependencies are not installing for packages. That's why these packages were moved to dependencies.