### PR TITLE
Removes autoprefixer-loader and jest-serializer-enzyme from the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     }
   ],
   "devDependencies": {
-    "autoprefixer-loader": "^3.2.0",
     "autoprefixer": "^7.1.1",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
@@ -69,7 +68,6 @@
     "extract-text-webpack-plugin": "~2.1.0",
     "fs-extra": "^3.0.1",
     "jest-cli": "^20.0.0",
-    "jest-serializer-enzyme": "^1.0.0",
     "jest": "^20.0.0",
     "node-sass": "^4.3.0",
     "postcss-loader": "~2.0.3",


### PR DESCRIPTION
# What does this PR do:
* Removes autoprefixer-loader and jest-serializer-enzyme which were not used anymore

# Where should the reviewer start:
  - Diffs