### PR TITLE
Move react-select from devDeps to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,30 +58,29 @@
     "coveralls": "^2.11.12",
     "create-react-class": "^15.5.2",
     "css-loader": "~0.28.1",
-    "enzyme-to-json": "^1.1.4",
     "enzyme": "^2.7.1",
+    "enzyme-to-json": "^1.1.4",
+    "eslint": "^3.14.0",
     "eslint-config-travix": "^3.0.0",
     "eslint-plugin-babel": "^4.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-react": "^7.0.1",
-    "eslint": "^3.14.0",
     "extract-text-webpack-plugin": "~2.1.0",
     "fs-extra": "^3.0.1",
-    "jest-cli": "^21.0.1",
     "jest": "^21.0.1",
+    "jest-cli": "^21.0.1",
     "node-sass": "^4.3.0",
     "postcss-loader": "~2.0.3",
     "prop-types": "^15.5.8",
+    "react": "^0.14.8",
     "react-addons-test-utils": "^0.14.8",
     "react-dom": "^0.14.8",
-    "react-select": "^1.0.0-rc.5",
     "react-styleguidist": "~5.1.10",
-    "react": "^0.14.8",
     "sass-loader": "~6.0.4",
     "style-loader": "~0.18.2",
     "theme-builder": "~0.5.0",
-    "webpack-hot-middleware": "^2.15.0",
-    "webpack": "~2.5.1"
+    "webpack": "~2.5.1",
+    "webpack-hot-middleware": "^2.15.0"
   },
   "greenkeeper": {
     "ignore": [
@@ -95,5 +94,8 @@
       "sass-loader",
       "webpack"
     ]
+  },
+  "dependencies": {
+    "react-select": "^1.0.0-rc.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
       "url": "https://github.com/mAiNiNfEcTiOn"
     }
   ],
+  "dependencies": {
+    "react-select": "^1.0.0-rc.5"
+  },
   "devDependencies": {
     "autoprefixer": "^7.1.1",
     "babel-cli": "^6.18.0",
@@ -94,8 +97,5 @@
       "sass-loader",
       "webpack"
     ]
-  },
-  "dependencies": {
-    "react-select": "^1.0.0-rc.5"
   }
 }


### PR DESCRIPTION
## WHAT DOES THIS PR DO: ##

* `react-select` package moved back to dependencies. Since we moved it out of it few errors have appeared (on tests and pipelines).

## WHERE SHOULD THE REVIEWER START: ##

* Diff

## UNIT TESTS: ##

* Passed