### PR TITLE
Changes our code coverage tool to use Code Cov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
   - 'npm run lint'
   - 'npm run cov'
 
-after_success: 'npm run coverage:coveralls'
+after_success: 'npm run coverage:report'
 
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "update-snapshots": "TZ=utc jest -c ./tests/jest.config.json -u",
     "cov": "TZ=utc jest -c ./tests/jest.config.json --coverage --no-cache",
     "coverage:coveralls": "cat ./coverage/lcov.info | coveralls",
+    "coverage:report": "codecov",
     "lint": "eslint --color '{components,tests,utils,scripts}/**/*.js'",
     "transpile": "npm run build"
   },
@@ -57,6 +58,7 @@
     "babel-preset-travix": "^1.1.0",
     "babel-register": "^6.16.3",
     "cheerio": "^0.22.0",
+    "codecov": "^2.3.0",
     "commander": "^2.9.0",
     "coveralls": "^2.11.12",
     "create-react-class": "^15.5.2",


### PR DESCRIPTION
# What does this PR do:

* Due to a lack of maintenance from Coveralls side, we're switching to Codecov. For that I've enabled CodeCov integration with our repos + configured our .travis.yml to send the reports.
* Also added the codecov dependency to the repo.

Later on I'll remove the `coveralls` package, once it works properly

# Where should the reviewer start:
  - `.travis.yml` and `package.json`