### PR TITLE
Removes coveralls dependency and changes the badge to connect to Codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/Travix-International/travix-ui-kit.svg)](https://greenkeeper.io/)
 
-[![npm](https://img.shields.io/npm/v/travix-ui-kit.svg)](https://www.npmjs.com/package/travix-ui-kit) [![Build Status](https://img.shields.io/travis/Travix-International/travix-ui-kit/master.svg)](http://travis-ci.org/Travix-International/travix-ui-kit) [![Coverage](https://img.shields.io/coveralls/Travix-International/travix-ui-kit.svg)](https://coveralls.io/github/Travix-International/travix-ui-kit) [![NSP Status](https://nodesecurity.io/orgs/travix-international-bv/projects/4757808e-0ffc-47dd-9c82-c48e782631dd/badge)](https://nodesecurity.io/orgs/travix-international-bv/projects/4757808e-0ffc-47dd-9c82-c48e782631dd)
+[![npm](https://img.shields.io/npm/v/travix-ui-kit.svg)](https://www.npmjs.com/package/travix-ui-kit) [![Build Status](https://img.shields.io/travis/Travix-International/travix-ui-kit/master.svg)](http://travis-ci.org/Travix-International/travix-ui-kit) [![coverage](https://codecov.io/gh/Travix-International/travix-ui-kit/branch/master/graph/badge.svg)](https://codecov.io/gh/Travix-International/travix-ui-kit)
+(https://coveralls.io/github/Travix-International/travix-ui-kit) [![NSP Status](https://nodesecurity.io/orgs/travix-international-bv/projects/4757808e-0ffc-47dd-9c82-c48e782631dd/badge)](https://nodesecurity.io/orgs/travix-international-bv/projects/4757808e-0ffc-47dd-9c82-c48e782631dd)
 
 Travix UI Components' repository.
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "cheerio": "^0.22.0",
     "codecov": "^2.3.0",
     "commander": "^2.9.0",
-    "coveralls": "^2.11.12",
     "create-react-class": "^15.5.2",
     "css-loader": "~0.28.1",
     "enzyme": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "test": "TZ=utc jest -c ./tests/jest.config.json",
     "update-snapshots": "TZ=utc jest -c ./tests/jest.config.json -u",
     "cov": "TZ=utc jest -c ./tests/jest.config.json --coverage --no-cache",
-    "coverage:coveralls": "cat ./coverage/lcov.info | coveralls",
     "coverage:report": "codecov",
     "lint": "eslint --color '{components,tests,utils,scripts}/**/*.js'",
     "transpile": "npm run build"

--- a/tests/jest.config.json
+++ b/tests/jest.config.json
@@ -11,6 +11,7 @@
     "js",
     "json"
   ],
+  "rootDir": "../",
   "snapshotSerializers": [
     "enzyme-to-json/serializer"
   ],


### PR DESCRIPTION
# What does this PR do:

* Removes `coveralls` from the `devDependencies` on `package.json`.
* Removes the task `coverage:coveralls` on `package.json`
* Changes the _coverage_ badge to use the one from Codecov, rather than the one from Coveralls.
* Updates `tests/jest.config.json` to contain the property `rootDir` pointing to the project's root path. This fixes the coverage report which Jest was retrieving as `All files: Unknown`

# Where should the reviewer start:
  - Check `package.json` and `README.md` changes