### PR TITLE
Adds 'set -e' to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: node_js
 node_js:
   - '6'
 
+before_install:
+  - set -e
+
 script:
   - 'npm run ci:lint'
   - 'npm run ci:test'


### PR DESCRIPTION
# What does this PR do:

  - Adds the flag `set -e` to the build process so that it stops the build as soon as it finds an error.

# Where should the reviewer start:
  - Check the failing build being stopped at `ci:lint` task: https://travis-ci.org/Travix-International/travix-ui-kit/jobs/274109638

Since there's another issue with the CI process, it is expected that the build fails 😉 