### PR TITLE
Fixes react-select's import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: node_js
 node_js:
   - '6'
 
+before_install:
+  - set -e
+
 script:
   - 'npm run ci:lint'
   - 'npm run ci:test'

--- a/components/dropDown/dropDown.js
+++ b/components/dropDown/dropDown.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Select from 'react-select/dist/react-select.min';
+import Select from 'react-select/dist/react-select';
 
 import { getClassNamesWithMods, getDataAttributes } from '../_helpers';
 import DropdownFilterOptionComponent from './dropdownFilterOptionComponent';

--- a/components/dropDown/dropDown.js
+++ b/components/dropDown/dropDown.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Select from 'react-select';
+import Select from 'react-select/dist/react-select.min';
 
 import { getClassNamesWithMods, getDataAttributes } from '../_helpers';
 import DropdownFilterOptionComponent from './dropdownFilterOptionComponent';

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "node ./builder/program",
     "ci:lint": "eslint --color --max-warnings 0 --quiet '{components,tests,utils,scripts}/**/*.js'",
     "ci:send-coverage": "codecov",
-    "ci:test": "TZ=utc jest -c ./tests/jest.config.json --bail --ci --coverage --no-cache --silent",
+    "ci:test": "TZ=utc jest -c ./tests/jest.config.json --bail --ci --coverage --maxWorkers=2 --no-cache --silent",
     "lint": "eslint --color '{components,tests,utils,scripts}/**/*.js'",
     "prebuild:watch": "babel --copy-files ./components --out-dir lib --ignore *.scss,*.md -w &",
     "prebuild": "babel --copy-files ./components --out-dir lib --ignore *.scss,*.md &",

--- a/tests/jest.config.json
+++ b/tests/jest.config.json
@@ -7,6 +7,14 @@
     "components/**/*.js",
     "!components/index.js"
   ],
+  "coverageThreshold": {
+    "global": {
+      "branches": 100,
+      "functions": 100,
+      "lines": 100,
+      "statements": 100
+    }
+  },
   "moduleFileExtensions": [
     "js",
     "json"

--- a/tests/unit/dropDown/__snapshots__/dropDown.render.spec.js.snap
+++ b/tests/unit/dropDown/__snapshots__/dropDown.render.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`DropDown: render should return base dropdown with passed array value 1`] = `
 <div>
-  <Select
+  <t
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -33,6 +33,7 @@ exports[`DropDown: render should return base dropdown with passed array value 1`
     onBlurResetsInput={true}
     onChange={[Function]}
     onCloseResetsInput={true}
+    onSelectResetsInput={true}
     optionComponent={[Function]}
     options={Array []}
     pageSize={5}
@@ -51,7 +52,7 @@ exports[`DropDown: render should return base dropdown with passed array value 1`
 
 exports[`DropDown: render should return base dropdown with passed number value 1`] = `
 <div>
-  <Select
+  <t
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -82,6 +83,7 @@ exports[`DropDown: render should return base dropdown with passed number value 1
     onBlurResetsInput={true}
     onChange={[Function]}
     onCloseResetsInput={true}
+    onSelectResetsInput={true}
     optionComponent={[Function]}
     options={Array []}
     pageSize={5}
@@ -100,7 +102,7 @@ exports[`DropDown: render should return base dropdown with passed number value 1
 
 exports[`DropDown: render should return base dropdown with passed string value 1`] = `
 <div>
-  <Select
+  <t
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -131,6 +133,7 @@ exports[`DropDown: render should return base dropdown with passed string value 1
     onBlurResetsInput={true}
     onChange={[Function]}
     onCloseResetsInput={true}
+    onSelectResetsInput={true}
     optionComponent={[Function]}
     options={Array []}
     pageSize={5}
@@ -149,7 +152,7 @@ exports[`DropDown: render should return base dropdown with passed string value 1
 
 exports[`DropDown: render should return base dropdown with required fields 1`] = `
 <div>
-  <Select
+  <t
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -180,6 +183,7 @@ exports[`DropDown: render should return base dropdown with required fields 1`] =
     onBlurResetsInput={true}
     onChange={[Function]}
     onCloseResetsInput={true}
+    onSelectResetsInput={true}
     optionComponent={[Function]}
     options={Array []}
     pageSize={5}
@@ -197,7 +201,7 @@ exports[`DropDown: render should return base dropdown with required fields 1`] =
 
 exports[`DropDown: render should return clearable dropdown 1`] = `
 <div>
-  <Select
+  <t
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -228,6 +232,7 @@ exports[`DropDown: render should return clearable dropdown 1`] = `
     onBlurResetsInput={true}
     onChange={[Function]}
     onCloseResetsInput={true}
+    onSelectResetsInput={true}
     optionComponent={[Function]}
     options={Array []}
     pageSize={5}
@@ -245,7 +250,7 @@ exports[`DropDown: render should return clearable dropdown 1`] = `
 
 exports[`DropDown: render should return dropdown with passed name 1`] = `
 <div>
-  <Select
+  <t
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -277,6 +282,7 @@ exports[`DropDown: render should return dropdown with passed name 1`] = `
     onBlurResetsInput={true}
     onChange={[Function]}
     onCloseResetsInput={true}
+    onSelectResetsInput={true}
     optionComponent={[Function]}
     options={Array []}
     pageSize={5}
@@ -294,7 +300,7 @@ exports[`DropDown: render should return dropdown with passed name 1`] = `
 
 exports[`DropDown: render should return dropdown with shifting viewport enabled 1`] = `
 <div>
-  <Select
+  <t
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -325,6 +331,7 @@ exports[`DropDown: render should return dropdown with shifting viewport enabled 
     onBlurResetsInput={true}
     onChange={[Function]}
     onCloseResetsInput={true}
+    onSelectResetsInput={true}
     optionComponent={[Function]}
     options={Array []}
     pageSize={5}
@@ -342,7 +349,7 @@ exports[`DropDown: render should return dropdown with shifting viewport enabled 
 
 exports[`DropDown: render should return dropdown with status 1`] = `
 <div>
-  <Select
+  <t
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -373,6 +380,7 @@ exports[`DropDown: render should return dropdown with status 1`] = `
     onBlurResetsInput={true}
     onChange={[Function]}
     onCloseResetsInput={true}
+    onSelectResetsInput={true}
     optionComponent={[Function]}
     options={Array []}
     pageSize={5}
@@ -390,7 +398,7 @@ exports[`DropDown: render should return dropdown with status 1`] = `
 
 exports[`DropDown: render should return filter dropdown 1`] = `
 <div>
-  <Select
+  <t
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -421,6 +429,7 @@ exports[`DropDown: render should return filter dropdown 1`] = `
     onBlurResetsInput={true}
     onChange={[Function]}
     onCloseResetsInput={true}
+    onSelectResetsInput={true}
     optionComponent={[Function]}
     options={
       Array [
@@ -444,7 +453,7 @@ exports[`DropDown: render should return filter dropdown 1`] = `
 
 exports[`DropDown: render should return multi dropdown 1`] = `
 <div>
-  <Select
+  <t
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -475,6 +484,7 @@ exports[`DropDown: render should return multi dropdown 1`] = `
     onBlurResetsInput={true}
     onChange={[Function]}
     onCloseResetsInput={true}
+    onSelectResetsInput={true}
     optionComponent={[Function]}
     options={Array []}
     pageSize={5}
@@ -492,7 +502,7 @@ exports[`DropDown: render should return multi dropdown 1`] = `
 
 exports[`DropDown: render should return searchable dropdown 1`] = `
 <div>
-  <Select
+  <t
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -523,6 +533,7 @@ exports[`DropDown: render should return searchable dropdown 1`] = `
     onBlurResetsInput={true}
     onChange={[Function]}
     onCloseResetsInput={true}
+    onSelectResetsInput={true}
     optionComponent={[Function]}
     options={Array []}
     pageSize={5}

--- a/tests/unit/dropDown/__snapshots__/dropDown.render.spec.js.snap
+++ b/tests/unit/dropDown/__snapshots__/dropDown.render.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`DropDown: render should return base dropdown with passed array value 1`] = `
 <div>
-  <t
+  <Select
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -52,7 +52,7 @@ exports[`DropDown: render should return base dropdown with passed array value 1`
 
 exports[`DropDown: render should return base dropdown with passed number value 1`] = `
 <div>
-  <t
+  <Select
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -102,7 +102,7 @@ exports[`DropDown: render should return base dropdown with passed number value 1
 
 exports[`DropDown: render should return base dropdown with passed string value 1`] = `
 <div>
-  <t
+  <Select
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -152,7 +152,7 @@ exports[`DropDown: render should return base dropdown with passed string value 1
 
 exports[`DropDown: render should return base dropdown with required fields 1`] = `
 <div>
-  <t
+  <Select
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -201,7 +201,7 @@ exports[`DropDown: render should return base dropdown with required fields 1`] =
 
 exports[`DropDown: render should return clearable dropdown 1`] = `
 <div>
-  <t
+  <Select
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -250,7 +250,7 @@ exports[`DropDown: render should return clearable dropdown 1`] = `
 
 exports[`DropDown: render should return dropdown with passed name 1`] = `
 <div>
-  <t
+  <Select
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -300,7 +300,7 @@ exports[`DropDown: render should return dropdown with passed name 1`] = `
 
 exports[`DropDown: render should return dropdown with shifting viewport enabled 1`] = `
 <div>
-  <t
+  <Select
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -349,7 +349,7 @@ exports[`DropDown: render should return dropdown with shifting viewport enabled 
 
 exports[`DropDown: render should return dropdown with status 1`] = `
 <div>
-  <t
+  <Select
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -398,7 +398,7 @@ exports[`DropDown: render should return dropdown with status 1`] = `
 
 exports[`DropDown: render should return filter dropdown 1`] = `
 <div>
-  <t
+  <Select
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -453,7 +453,7 @@ exports[`DropDown: render should return filter dropdown 1`] = `
 
 exports[`DropDown: render should return multi dropdown 1`] = `
 <div>
-  <t
+  <Select
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}
@@ -502,7 +502,7 @@ exports[`DropDown: render should return multi dropdown 1`] = `
 
 exports[`DropDown: render should return searchable dropdown 1`] = `
 <div>
-  <t
+  <Select
     addLabelText="Add \\"{label}\\"?"
     arrowRenderer={[Function]}
     autosize={true}


### PR DESCRIPTION
# What does this PR do:

  - Due to changes in the releases > `v1.0.0-rc.5`, `react-select` broke the way we import it on the code. One way I found that worked was using their `dist/react-select.min.js` file. (I'm open for a proper, better solution if you have, but please try it locally).

# Where should the reviewer start:
  - Diffs
  - Build should pass now

(More info at: https://github.com/JedWatson/react-select/compare/v1.0.0-rc.5...v1.0.0-rc.7)

Closes #170

