### PR TITLE
Removes the remainders of the Coveralls badge and re-orders badges on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Travix UI-kit
 
+[![npm](https://img.shields.io/npm/v/travix-ui-kit.svg)](https://www.npmjs.com/package/travix-ui-kit)
+[![Build Status](https://img.shields.io/travis/Travix-International/travix-ui-kit/master.svg)](http://travis-ci.org/Travix-International/travix-ui-kit)
+[![coverage](https://codecov.io/gh/Travix-International/travix-ui-kit/branch/master/graph/badge.svg)](https://codecov.io/gh/Travix-International/travix-ui-kit)
 [![Greenkeeper badge](https://badges.greenkeeper.io/Travix-International/travix-ui-kit.svg)](https://greenkeeper.io/)
-
-[![npm](https://img.shields.io/npm/v/travix-ui-kit.svg)](https://www.npmjs.com/package/travix-ui-kit) [![Build Status](https://img.shields.io/travis/Travix-International/travix-ui-kit/master.svg)](http://travis-ci.org/Travix-International/travix-ui-kit) [![coverage](https://codecov.io/gh/Travix-International/travix-ui-kit/branch/master/graph/badge.svg)](https://codecov.io/gh/Travix-International/travix-ui-kit)
-(https://coveralls.io/github/Travix-International/travix-ui-kit) [![NSP Status](https://nodesecurity.io/orgs/travix-international-bv/projects/4757808e-0ffc-47dd-9c82-c48e782631dd/badge)](https://nodesecurity.io/orgs/travix-international-bv/projects/4757808e-0ffc-47dd-9c82-c48e782631dd)
+[![NSP Status](https://nodesecurity.io/orgs/travix-international-bv/projects/4757808e-0ffc-47dd-9c82-c48e782631dd/badge)](https://nodesecurity.io/orgs/travix-international-bv/projects/4757808e-0ffc-47dd-9c82-c48e782631dd)
 
 Travix UI Components' repository.
 


### PR DESCRIPTION
# What does this PR do:

* Removes the remainders of the Coveralls badge

* Re-orders the badges so that NPM is first, then build and code coverage, and only after that it comes the integrations (Greenkeeper and Node Security Platform)

# Where should the reviewer start:
  - If you look at our README.md on `master` you will notice that it contains remainders of the _coveralls_ badge on it, which needed to be removed. That's what this is fixing :)