### PR TITLE
Tooltip fix: increased z-index to prevent overlapping

### DIFF
--- a/components/tooltip/tooltip.scss
+++ b/components/tooltip/tooltip.scss
@@ -6,7 +6,7 @@
   min-height: 60px;
   padding: 12px;
   position: absolute;
-  z-index: 1;
+  z-index: 1000;
 }
 
 .ui-tooltip::before {
@@ -16,7 +16,7 @@
   position: absolute;
   transform: rotate(45deg);
   width: 15px;
-  z-index: 2;
+  z-index: 10001;
 }
 
 .ui-tooltip_top {


### PR DESCRIPTION
# What does this PR do:

    Increased z-index to prevent any overlapping.

# Where should the reviewer start:

    components/tooltip/tooltip.scss
