### PR TITLE
Add "className" prop to button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ themes/theme.scss
 .DS_Store
 wallaby.js
 _site
+package-lock.json

--- a/components/button/button.js
+++ b/components/button/button.js
@@ -1,4 +1,5 @@
 // Imports
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { getClassNamesWithMods, getDataAttributes } from '../_helpers';
@@ -9,6 +10,7 @@ import { getClassNamesWithMods, getDataAttributes } from '../_helpers';
 function Button(props) {
   const {
     children,
+    className,
     size,
     href,
     onClick,
@@ -27,7 +29,10 @@ function Button(props) {
     mods.push(`disabled_true`);
   }
 
-  const className = getClassNamesWithMods('ui-button', mods);
+  const classes = classnames(
+    getClassNamesWithMods('ui-button', mods),
+    className
+  );
 
   if (type === 'link') {
     if (!href) {
@@ -36,19 +41,19 @@ function Button(props) {
     }
 
     return (
-      <a className={className} href={href} {...restProps}>{children}</a>
+      <a className={classes} href={href} {...restProps}>{children}</a>
     );
   }
 
   if (type === 'submit' || type === 'reset') {
     return (
-      <button className={className} disabled={disabled} type={type} {...restProps}>{children}</button>
+      <button className={classes} disabled={disabled} type={type} {...restProps}>{children}</button>
     );
   }
 
   return (
     <button
-      className={className}
+      className={classes}
       disabled={disabled}
       onClick={onClick}
       type="button"
@@ -75,6 +80,12 @@ Button.propTypes = {
     PropTypes.element,
     PropTypes.node,
   ]).isRequired,
+
+  /**
+   * Attribute used to set specific classes which will be combined
+   * with the "ui-button" class + mods.
+   */
+  className: PropTypes.string,
 
   /**
    * Data attribute. You can use it to set up GTM key or any custom data-* attribute

--- a/components/button/button.md
+++ b/components/button/button.md
@@ -4,6 +4,7 @@ Basic button:
       <Button onClick={alert}>Show alert</Button><br/><br/>
       <Button onClick={alert} disabled={true}>Disabled</Button><br/><br/>
       <Button dataAttrs={{gtm: 'some-id'}} type="reset">With GTM id</Button><br/><br/>
+      <Button className="my-class">Example with custom class set</Button><br/><br/>
     </div>
 
 Sizes:
@@ -34,4 +35,4 @@ Variations - Link:
         You can put a <Button onClick={alert} variation="link">link button</Button><br/> along with regular text.
       </p>
     </div>
-    
+

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     }
   ],
   "dependencies": {
+    "classnames": "^2.2.5",
     "react-select": "^1.0.0-rc.5"
   },
   "devDependencies": {


### PR DESCRIPTION
# What does this PR do:
* Adds `classnames` as a package dependency
* Changes the `Button` component to support the `className` attribute. This is particularly important for CSS Modules since we need to pass a specific CSS Modules' class to style the element.
Also we don't want to follow the BEM style which the _mods_ attribute enforces.

* Also added an example with a custom class set.

# Where should the reviewer start:
  - Diffs
  - Check the styleguide :)