### PR TITLE
Improves the calendar/views/days.js to not use .bind() according to react/jsx-no-bind lint rule

### DIFF
--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -231,7 +231,7 @@ export default class Calendar extends Component {
           onMouseDown={this.handleItemMouseDown}
           onNavNextMonth={() => this.moveToMonth(CALENDAR_MOVE_TO_NEXT)}
           onNavPreviousMonth={() => this.moveToMonth(CALENDAR_MOVE_TO_PREVIOUS)}
-          onSelectDay={dt => this.onSelectDay(dt)}
+          onSelectDay={e => this.onSelectDay(new Date(e.currentTarget.getAttribute('data-date')))}
           renderDate={renderDate}
           selectedDates={selectedDates}
           selectionType={selectionType}

--- a/components/calendar/views/days.js
+++ b/components/calendar/views/days.js
@@ -92,7 +92,7 @@ class Days extends Component {
       (maxDate && (maxDate.getTime() < dateToBeRendered.getTime())) ||
       (minDate && (minDate.getTime() > dateToBeRendered.getTime())) ||
       (isDaySelectableFn && !isDaySelectableFn(dateToBeRendered))
-     ) {
+    ) {
       return false;
     }
 
@@ -166,8 +166,6 @@ class Days extends Component {
         currentDate.getFullYear(),
       ].join(' ');
 
-      const onClickHandler = onSelectDay.bind(null, new Date(currentDate.toDateString()));
-
       options.push(
         <button
           aria-label={ariaLabel}
@@ -176,7 +174,7 @@ class Days extends Component {
           data-date={dateInYYYYMMDD}
           disabled={!this.isOptionEnabled(currentDate)}
           key={`option_${counter}`}
-          onClick={onClickHandler}
+          onClick={onSelectDay}
           role="gridcell"
           type="button"
         >{currentDate.getDate()}</button>


### PR DESCRIPTION
# What does this PR do:

* Changes the `onSelectDay` method on `calendar.js` to use the `data-date` attribute from the `event's currentTarget` (which is provided from the `calendar/views/days.js` button.

# Where should the reviewer start:
  - Diffs
