### PR TITLE
Added ability to use or not use touch events for track of carousel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Change Log
 
+## [v0.7.3](https://github.com/Travix-International/travix-ui-kit/tree/v0.7.3) (2017-11-28)
+
+[Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.7.2...v0.7.3)
+
+**Closed issues:**
+
+- GH-pages: Link's labels are unreadable [\#246](https://github.com/Travix-International/travix-ui-kit/issues/246)
+- Extend Price component to support vertical align customization for its items [\#187](https://github.com/Travix-International/travix-ui-kit/issues/187)
+- Button variations is not working [\#73](https://github.com/Travix-International/travix-ui-kit/issues/73)
+
+**Merged pull requests:**
+
+- Add unstyled prop to Price component [\#250](https://github.com/Travix-International/travix-ui-kit/pull/250) ([yurist38](https://github.com/yurist38))
+- Updated deploy:accp script to prepend the generated now url with branch name [\#241](https://github.com/Travix-International/travix-ui-kit/pull/241) ([reaktivo](https://github.com/reaktivo))
+- Fix Unknown Prop Warning [\#227](https://github.com/Travix-International/travix-ui-kit/pull/227) ([AlleeX](https://github.com/AlleeX))
+
 ## [v0.7.2](https://github.com/Travix-International/travix-ui-kit/tree/v0.7.2) (2017-11-21)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.7.0...v0.7.2)
 
 **Closed issues:**
@@ -22,6 +39,7 @@
 - Refactoring of List component [\#232](https://github.com/Travix-International/travix-ui-kit/pull/232) ([yurist38](https://github.com/yurist38))
 
 ## [v0.7.0](https://github.com/Travix-International/travix-ui-kit/tree/v0.7.0) (2017-11-15)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.38...v0.7.0)
 
 **Merged pull requests:**
@@ -29,6 +47,7 @@
 - Updates to React 16 [\#231](https://github.com/Travix-International/travix-ui-kit/pull/231) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
 ## [v0.6.38](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.38) (2017-11-15)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.37...v0.6.38)
 
 **Merged pull requests:**
@@ -36,6 +55,7 @@
 - Update price with asterisk and vertical align [\#224](https://github.com/Travix-International/travix-ui-kit/pull/224) ([IvanPresmytsky](https://github.com/IvanPresmytsky))
 
 ## [v0.6.37](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.37) (2017-11-09)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.36...v0.6.37)
 
 **Closed issues:**
@@ -49,6 +69,7 @@
 - Upgraded enzyme to version 3, fixed tests [\#222](https://github.com/Travix-International/travix-ui-kit/pull/222) ([yurist38](https://github.com/yurist38))
 
 ## [v0.6.36](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.36) (2017-11-02)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.35...v0.6.36)
 
 **Merged pull requests:**
@@ -57,6 +78,7 @@
 - Change ToggleButton component to a functional, stateless component [\#206](https://github.com/Travix-International/travix-ui-kit/pull/206) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
 ## [v0.6.35](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.35) (2017-10-31)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.34...v0.6.35)
 
 **Merged pull requests:**
@@ -68,6 +90,7 @@
 - Update codecov to the latest version 🚀 [\#208](https://github.com/Travix-International/travix-ui-kit/pull/208) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
 
 ## [v0.6.34](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.34) (2017-10-25)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.33...v0.6.34)
 
 **Merged pull requests:**
@@ -75,6 +98,7 @@
 - Fixed issue with button colors [\#210](https://github.com/Travix-International/travix-ui-kit/pull/210) ([MadinaShad](https://github.com/MadinaShad))
 
 ## [v0.6.33](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.33) (2017-10-25)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.32...v0.6.33)
 
 **Merged pull requests:**
@@ -84,6 +108,7 @@
 - Fix documentation [\#202](https://github.com/Travix-International/travix-ui-kit/pull/202) ([AlleeX](https://github.com/AlleeX))
 
 ## [v0.6.32](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.32) (2017-10-12)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.31...v0.6.32)
 
 **Merged pull requests:**
@@ -92,6 +117,7 @@
 - Changes the ToggleButton component to accept classNames [\#200](https://github.com/Travix-International/travix-ui-kit/pull/200) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
 ## [v0.6.31](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.31) (2017-10-11)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.30...v0.6.31)
 
 **Fixed bugs:**
@@ -104,6 +130,7 @@
 - Fixes the demo for the sidepanel [\#198](https://github.com/Travix-International/travix-ui-kit/pull/198) ([RumataDeEstor](https://github.com/RumataDeEstor))
 
 ## [v0.6.30](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.30) (2017-10-04)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.29...v0.6.30)
 
 **Merged pull requests:**
@@ -111,6 +138,7 @@
 - fixes NodeList to Array [\#197](https://github.com/Travix-International/travix-ui-kit/pull/197) ([froskie](https://github.com/froskie))
 
 ## [v0.6.29](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.29) (2017-10-02)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.28...v0.6.29)
 
 **Merged pull requests:**
@@ -118,6 +146,7 @@
 - Modal and price minor improvements [\#193](https://github.com/Travix-International/travix-ui-kit/pull/193) ([RumataDeEstor](https://github.com/RumataDeEstor))
 
 ## [v0.6.28](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.28) (2017-09-20)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.27...v0.6.28)
 
 **Merged pull requests:**
@@ -126,6 +155,7 @@
 - Update enzyme-to-json to the latest version 🚀 [\#188](https://github.com/Travix-International/travix-ui-kit/pull/188) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
 
 ## [v0.6.27](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.27) (2017-09-14)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.26...v0.6.27)
 
 **Merged pull requests:**
@@ -133,6 +163,7 @@
 - Tooltip fix: increased z-index to prevent overlapping [\#186](https://github.com/Travix-International/travix-ui-kit/pull/186) ([RumataDeEstor](https://github.com/RumataDeEstor))
 
 ## [v0.6.26](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.26) (2017-09-14)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.25...v0.6.26)
 
 **Fixed bugs:**
@@ -160,6 +191,7 @@
 - Adds 'set -e' to .travis.yml [\#171](https://github.com/Travix-International/travix-ui-kit/pull/171) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
 ## [v0.6.25](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.25) (2017-09-08)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.24...v0.6.25)
 
 **Merged pull requests:**
@@ -167,6 +199,7 @@
 - Tooltip: fixed styling issue [\#169](https://github.com/Travix-International/travix-ui-kit/pull/169) ([RumataDeEstor](https://github.com/RumataDeEstor))
 
 ## [v0.6.24](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.24) (2017-09-07)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.23...v0.6.24)
 
 **Closed issues:**
@@ -183,6 +216,7 @@
 - Tooltip component [\#155](https://github.com/Travix-International/travix-ui-kit/pull/155) ([RumataDeEstor](https://github.com/RumataDeEstor))
 
 ## [v0.6.23](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.23) (2017-09-05)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.22...v0.6.23)
 
 **Merged pull requests:**
@@ -194,6 +228,7 @@
 - Create CODE\_OF\_CONDUCT.md [\#157](https://github.com/Travix-International/travix-ui-kit/pull/157) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
 ## [v0.6.22](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.22) (2017-09-04)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.21...v0.6.22)
 
 **Merged pull requests:**
@@ -201,6 +236,7 @@
 - collapse component adjustments [\#156](https://github.com/Travix-International/travix-ui-kit/pull/156) ([maximuk](https://github.com/maximuk))
 
 ## [v0.6.21](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.21) (2017-09-04)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.20...v0.6.21)
 
 **Closed issues:**
@@ -229,6 +265,7 @@
 - Update jest-cli to the latest version 🚀 [\#80](https://github.com/Travix-International/travix-ui-kit/pull/80) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
 
 ## [v0.6.20](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.20) (2017-08-29)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.19...v0.6.20)
 
 **Closed issues:**
@@ -243,6 +280,7 @@
 - Input and dropdown improvements [\#149](https://github.com/Travix-International/travix-ui-kit/pull/149) ([maximuk](https://github.com/maximuk))
 
 ## [v0.6.19](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.19) (2017-08-17)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.18...v0.6.19)
 
 **Closed issues:**
@@ -256,6 +294,7 @@
 - Changes the components to use the 'prop-types' package [\#145](https://github.com/Travix-International/travix-ui-kit/pull/145) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
 ## [v0.6.18](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.18) (2017-08-11)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.17...v0.6.18)
 
 **Merged pull requests:**
@@ -264,6 +303,7 @@
 - Adds public API Key for Google Maps to the styleguide's HTML [\#142](https://github.com/Travix-International/travix-ui-kit/pull/142) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
 ## [v0.6.17](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.17) (2017-08-10)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.16...v0.6.17)
 
 **Merged pull requests:**
@@ -275,6 +315,7 @@
 - Update dependencies to enable Greenkeeper 🌴 [\#102](https://github.com/Travix-International/travix-ui-kit/pull/102) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
 
 ## [v0.6.16](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.16) (2017-08-02)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.15...v0.6.16)
 
 **Merged pull requests:**
@@ -282,6 +323,7 @@
 - Message box [\#133](https://github.com/Travix-International/travix-ui-kit/pull/133) ([iwwwi](https://github.com/iwwwi))
 
 ## [v0.6.15](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.15) (2017-08-02)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.14...v0.6.15)
 
 **Closed issues:**
@@ -294,6 +336,7 @@
 - Improves the polyfill loader to use feature detection [\#131](https://github.com/Travix-International/travix-ui-kit/pull/131) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
 ## [v0.6.14](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.14) (2017-07-18)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.13...v0.6.14)
 
 **Merged pull requests:**
@@ -301,9 +344,11 @@
 - Carousel swipe refactor [\#130](https://github.com/Travix-International/travix-ui-kit/pull/130) ([froskie](https://github.com/froskie))
 
 ## [v0.6.13](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.13) (2017-07-13)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.12...v0.6.13)
 
 ## [v0.6.12](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.12) (2017-07-13)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.11...v0.6.12)
 
 **Closed issues:**
@@ -317,6 +362,7 @@
 - Collapse component adjustments [\#125](https://github.com/Travix-International/travix-ui-kit/pull/125) ([RumataDeEstor](https://github.com/RumataDeEstor))
 
 ## [v0.6.11](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.11) (2017-07-11)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.10...v0.6.11)
 
 **Merged pull requests:**
@@ -324,6 +370,7 @@
 - Fix datepicker demo [\#124](https://github.com/Travix-International/travix-ui-kit/pull/124) ([AlleeX](https://github.com/AlleeX))
 
 ## [v0.6.10](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.10) (2017-07-11)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.9...v0.6.10)
 
 **Fixed bugs:**
@@ -343,6 +390,7 @@
 - Fixes typo on the UserAgent detection [\#120](https://github.com/Travix-International/travix-ui-kit/pull/120) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
 ## [v0.6.9](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.9) (2017-07-01)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.8...v0.6.9)
 
 **Fixed bugs:**
@@ -350,6 +398,7 @@
 - Adds polyfilling support for CSS Variables [\#119](https://github.com/Travix-International/travix-ui-kit/pull/119) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
 ## [v0.6.8](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.8) (2017-06-29)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.7...v0.6.8)
 
 **Fixed bugs:**
@@ -361,6 +410,7 @@
 - Change SlidingPanel to use the refs [\#116](https://github.com/Travix-International/travix-ui-kit/pull/116) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
 ## [v0.6.7](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.7) (2017-06-28)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.6...v0.6.7)
 
 **Fixed bugs:**
@@ -368,6 +418,7 @@
 - \#109 modal bug [\#115](https://github.com/Travix-International/travix-ui-kit/pull/115) ([froskie](https://github.com/froskie))
 
 ## [v0.6.6](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.6) (2017-06-28)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.5...v0.6.6)
 
 **Merged pull requests:**
@@ -375,6 +426,7 @@
 - HOT-FIX for export rating component [\#114](https://github.com/Travix-International/travix-ui-kit/pull/114) ([AlleeX](https://github.com/AlleeX))
 
 ## [v0.6.5](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.5) (2017-06-28)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.4...v0.6.5)
 
 **Closed issues:**
@@ -388,6 +440,7 @@
 - Adds the SlidingPanel component [\#111](https://github.com/Travix-International/travix-ui-kit/pull/111) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
 ## [v0.6.4](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.4) (2017-06-24)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.3...v0.6.4)
 
 **Merged pull requests:**
@@ -396,6 +449,7 @@
 - adds ghost button [\#106](https://github.com/Travix-International/travix-ui-kit/pull/106) ([froskie](https://github.com/froskie))
 
 ## [v0.6.3](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.3) (2017-06-22)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.2...v0.6.3)
 
 **Closed issues:**
@@ -408,6 +462,7 @@
 - Handle building intermediate directories when outputing files [\#104](https://github.com/Travix-International/travix-ui-kit/pull/104) ([reaktivo](https://github.com/reaktivo))
 
 ## [v0.6.2](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.2) (2017-06-19)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.1...v0.6.2)
 
 **Closed issues:**
@@ -419,9 +474,11 @@
 - Added Badge component [\#101](https://github.com/Travix-International/travix-ui-kit/pull/101) ([maximuk](https://github.com/maximuk))
 
 ## [v0.6.1](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.1) (2017-06-01)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.6.0...v0.6.1)
 
 ## [v0.6.0](https://github.com/Travix-International/travix-ui-kit/tree/v0.6.0) (2017-06-01)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.5.2...v0.6.0)
 
 **Closed issues:**
@@ -434,6 +491,7 @@
 - Convert SCSS Variables into CSS Custom Properties/Variables [\#99](https://github.com/Travix-International/travix-ui-kit/pull/99) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
 ## [v0.5.2](https://github.com/Travix-International/travix-ui-kit/tree/v0.5.2) (2017-05-18)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.5.1...v0.5.2)
 
 **Merged pull requests:**
@@ -441,6 +499,7 @@
 - Components props improvements [\#94](https://github.com/Travix-International/travix-ui-kit/pull/94) ([RumataDeEstor](https://github.com/RumataDeEstor))
 
 ## [v0.5.1](https://github.com/Travix-International/travix-ui-kit/tree/v0.5.1) (2017-05-11)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.5.0...v0.5.1)
 
 **Merged pull requests:**
@@ -449,6 +508,7 @@
 - Improvements for CollapseItem component [\#76](https://github.com/Travix-International/travix-ui-kit/pull/76) ([EduardTrutsyk](https://github.com/EduardTrutsyk))
 
 ## [v0.5.0](https://github.com/Travix-International/travix-ui-kit/tree/v0.5.0) (2017-05-10)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.4.8...v0.5.0)
 
 **Closed issues:**
@@ -463,6 +523,7 @@
 - Update button.js [\#74](https://github.com/Travix-International/travix-ui-kit/pull/74) ([asci](https://github.com/asci))
 
 ## [v0.4.8](https://github.com/Travix-International/travix-ui-kit/tree/v0.4.8) (2017-05-04)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.4.7...v0.4.8)
 
 **Merged pull requests:**
@@ -470,6 +531,7 @@
 - Improvements for autoComplete, dropDown and button components [\#75](https://github.com/Travix-International/travix-ui-kit/pull/75) ([AlleeX](https://github.com/AlleeX))
 
 ## [v0.4.7](https://github.com/Travix-International/travix-ui-kit/tree/v0.4.7) (2017-05-02)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.4.6...v0.4.7)
 
 **Merged pull requests:**
@@ -477,6 +539,7 @@
 - added package dependencies + missing list vars to fix the build [\#70](https://github.com/Travix-International/travix-ui-kit/pull/70) ([iwwwi](https://github.com/iwwwi))
 
 ## [v0.4.6](https://github.com/Travix-International/travix-ui-kit/tree/v0.4.6) (2017-04-26)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.4.5...v0.4.6)
 
 **Merged pull requests:**
@@ -484,6 +547,7 @@
 - Added variables to the List classes [\#69](https://github.com/Travix-International/travix-ui-kit/pull/69) ([AlexDudar](https://github.com/AlexDudar))
 
 ## [v0.4.5](https://github.com/Travix-International/travix-ui-kit/tree/v0.4.5) (2017-04-20)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.4.4...v0.4.5)
 
 **Merged pull requests:**
@@ -492,6 +556,7 @@
 - Autocomplete and Input [\#66](https://github.com/Travix-International/travix-ui-kit/pull/66) ([AlleeX](https://github.com/AlleeX))
 
 ## [v0.4.4](https://github.com/Travix-International/travix-ui-kit/tree/v0.4.4) (2017-04-14)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.4.3...v0.4.4)
 
 **Closed issues:**
@@ -504,6 +569,7 @@
 - Update react-styleguidist to the latest version 🚀 [\#56](https://github.com/Travix-International/travix-ui-kit/pull/56) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
 
 ## [v0.4.3](https://github.com/Travix-International/travix-ui-kit/tree/v0.4.3) (2017-04-07)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.4.2...v0.4.3)
 
 **Closed issues:**
@@ -518,6 +584,7 @@
 - Add posibility to pass mods through `props` in modal component [\#63](https://github.com/Travix-International/travix-ui-kit/pull/63) ([juliamaksimchik](https://github.com/juliamaksimchik))
 
 ## [v0.4.2](https://github.com/Travix-International/travix-ui-kit/tree/v0.4.2) (2017-04-06)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.4.1...v0.4.2)
 
 **Merged pull requests:**
@@ -525,6 +592,7 @@
 - Improvements for Modal component [\#61](https://github.com/Travix-International/travix-ui-kit/pull/61) ([EduardTrutsyk](https://github.com/EduardTrutsyk))
 
 ## [v0.4.1](https://github.com/Travix-International/travix-ui-kit/tree/v0.4.1) (2017-04-04)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.4.0...v0.4.1)
 
 **Merged pull requests:**
@@ -532,6 +600,7 @@
 - Dropdown and Checkbox component [\#49](https://github.com/Travix-International/travix-ui-kit/pull/49) ([AlleeX](https://github.com/AlleeX))
 
 ## [v0.4.0](https://github.com/Travix-International/travix-ui-kit/tree/v0.4.0) (2017-04-03)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.3.6...v0.4.0)
 
 **Merged pull requests:**
@@ -540,6 +609,7 @@
 - Added ability to merge yaml files and override default theme [\#55](https://github.com/Travix-International/travix-ui-kit/pull/55) ([EduardTrutsyk](https://github.com/EduardTrutsyk))
 
 ## [v0.3.6](https://github.com/Travix-International/travix-ui-kit/tree/v0.3.6) (2017-03-28)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.3.5...v0.3.6)
 
 **Fixed bugs:**
@@ -553,6 +623,7 @@
 - ESlint improvements [\#46](https://github.com/Travix-International/travix-ui-kit/pull/46) ([asci](https://github.com/asci))
 
 ## [v0.3.5](https://github.com/Travix-International/travix-ui-kit/tree/v0.3.5) (2017-03-23)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.3.4...v0.3.5)
 
 **Fixed bugs:**
@@ -570,6 +641,7 @@
 - Collapse component [\#44](https://github.com/Travix-International/travix-ui-kit/pull/44) ([EduardTrutsyk](https://github.com/EduardTrutsyk))
 
 ## [v0.3.4](https://github.com/Travix-International/travix-ui-kit/tree/v0.3.4) (2017-03-17)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.3.3...v0.3.4)
 
 **Merged pull requests:**
@@ -577,6 +649,7 @@
 - Extend default theme by custom theme [\#43](https://github.com/Travix-International/travix-ui-kit/pull/43) ([asci](https://github.com/asci))
 
 ## [v0.3.3](https://github.com/Travix-International/travix-ui-kit/tree/v0.3.3) (2017-03-16)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.3.2...v0.3.3)
 
 **Fixed bugs:**
@@ -591,6 +664,7 @@
 - Fixes typo on README.md [\#33](https://github.com/Travix-International/travix-ui-kit/pull/33) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
 ## [v0.3.2](https://github.com/Travix-International/travix-ui-kit/tree/v0.3.2) (2017-03-09)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.3.1...v0.3.2)
 
 **Fixed bugs:**
@@ -598,6 +672,7 @@
 - Fixes issue \#31 - Changes the builder to properly catch rejections and to output the errors on the webpack process [\#32](https://github.com/Travix-International/travix-ui-kit/pull/32) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
 ## [v0.3.1](https://github.com/Travix-International/travix-ui-kit/tree/v0.3.1) (2017-03-03)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.3.0...v0.3.1)
 
 **Fixed bugs:**
@@ -619,6 +694,7 @@
 - Added List component [\#16](https://github.com/Travix-International/travix-ui-kit/pull/16) ([AlexDudar](https://github.com/AlexDudar))
 
 ## [v0.3.0](https://github.com/Travix-International/travix-ui-kit/tree/v0.3.0) (2017-02-15)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.2.3...v0.3.0)
 
 **Closed issues:**
@@ -630,6 +706,7 @@
 - \[WIP\] Implementation of issue \#6's proposal [\#7](https://github.com/Travix-International/travix-ui-kit/pull/7) ([mAiNiNfEcTiOn](https://github.com/mAiNiNfEcTiOn))
 
 ## [v0.2.3](https://github.com/Travix-International/travix-ui-kit/tree/v0.2.3) (2017-02-14)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.2.2...v0.2.3)
 
 **Closed issues:**
@@ -642,6 +719,7 @@
 - Update sass-loader to the latest version 🚀 [\#9](https://github.com/Travix-International/travix-ui-kit/pull/9) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
 
 ## [v0.2.2](https://github.com/Travix-International/travix-ui-kit/tree/v0.2.2) (2017-01-26)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.2.1...v0.2.2)
 
 **Merged pull requests:**
@@ -649,6 +727,7 @@
 - removed node\_modules from webpack scss loader [\#5](https://github.com/Travix-International/travix-ui-kit/pull/5) ([iwwwi](https://github.com/iwwwi))
 
 ## [v0.2.1](https://github.com/Travix-International/travix-ui-kit/tree/v0.2.1) (2017-01-19)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.2.0...v0.2.1)
 
 **Merged pull requests:**
@@ -656,6 +735,7 @@
 - downgrade webpack and extract-text-webpack-plugin version [\#4](https://github.com/Travix-International/travix-ui-kit/pull/4) ([iwwwi](https://github.com/iwwwi))
 
 ## [v0.2.0](https://github.com/Travix-International/travix-ui-kit/tree/v0.2.0) (2017-01-18)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.1.2...v0.2.0)
 
 **Merged pull requests:**
@@ -663,6 +743,7 @@
 - Update dependencies to enable Greenkeeper 🌴 [\#2](https://github.com/Travix-International/travix-ui-kit/pull/2) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
 
 ## [v0.1.2](https://github.com/Travix-International/travix-ui-kit/tree/v0.1.2) (2017-01-18)
+
 [Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/v0.1.1...v0.1.2)
 
 **Merged pull requests:**
@@ -670,6 +751,9 @@
 - updated readme.md makefile and maintainers.md [\#3](https://github.com/Travix-International/travix-ui-kit/pull/3) ([iwwwi](https://github.com/iwwwi))
 
 ## [v0.1.1](https://github.com/Travix-International/travix-ui-kit/tree/v0.1.1) (2017-01-17)
+
+[Full Changelog](https://github.com/Travix-International/travix-ui-kit/compare/2ee1b29a67f5e1f333cc587df08ceb51c2de07c8...v0.1.1)
+
 **Merged pull requests:**
 
 - added initial files for ui-kit [\#1](https://github.com/Travix-International/travix-ui-kit/pull/1) ([iwwwi](https://github.com/iwwwi))

--- a/components/carousel/carousel.js
+++ b/components/carousel/carousel.js
@@ -108,7 +108,8 @@ export default class Carousel extends React.Component {
   }
 
   render() {
-    const restProps = getDataAttributes(this.props.dataAttrs);
+    const { touchable, dataAttrs, images } = this.props;
+    const restProps = getDataAttributes(dataAttrs);
 
     const carouselMods = this.props.mods ? this.props.mods.slice() : [];
     const carouselClass = getClassNamesWithMods('ui-carousel', carouselMods);
@@ -119,10 +120,11 @@ export default class Carousel extends React.Component {
           current={this.state.currentItem}
           onNext={this.handleSwipeNext}
           onPrev={this.handleSwipePrev}
+          touchable={touchable}
         >
-          {this.props.images.map((src, i) => <CarouselItem key={i} load={this.shouldLoad(i)} src={src} />)}
+          {images.map((src, i) => <CarouselItem key={i} load={this.shouldLoad(i)} src={src} />)}
         </CarouselTrack>
-        {this.props.images.length > 1 && this.renderNavigation()}
+        {images.length > 1 && this.renderNavigation()}
       </div>
     );
   }
@@ -157,12 +159,17 @@ Carousel.propTypes = {
    * Initial index being displayed
    */
   current: PropTypes.number,
+  /**
+   * Ability to use touch events for track
+   */
+  touchable: PropTypes.bool,
 };
 
 Carousel.defaultProps = {
+  current: 0,
   images: [],
   markers: false,
-  prevButton: <span>&lsaquo;</span>,
   nextButton: <span>&rsaquo;</span>,
-  current: 0,
+  prevButton: <span>&lsaquo;</span>,
+  touchable: true,
 };

--- a/components/carousel/carousel.md
+++ b/components/carousel/carousel.md
@@ -1,7 +1,19 @@
 Carousel:
 
+    initialState = {
+      touchable: true,
+    };
+
     <div>
+      <Checkbox
+        checked={state.touchable}
+        name="touchable"
+        onChange={() => setState({ touchable: !state.touchable })}
+      >
+        touchable
+      </Checkbox>
       <Carousel
+        touchable={state.touchable}
         images={[
           'http://lorempixel.com/600/400/city',
           'http://lorempixel.com/600/400/sports',

--- a/components/carousel/carouselTrack.js
+++ b/components/carousel/carouselTrack.js
@@ -23,18 +23,22 @@ class CarouselTrack extends Component {
   }
 
   componentDidMount() {
-    this.bindEvents();
+    this.props.touchable && this.bindEvents();
     this.$elm.style.willChange = 'transform';
     this.setupSlidePosition();
   }
 
   componentWillUnmount() {
-    this.unbindEvents();
+    this.props.touchable && this.unbindEvents();
   }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.current !== this.props.current) {
       this.resetSlidePosition(nextProps.current);
+    }
+
+    if (nextProps.touchable !== this.props.touchable) {
+      nextProps.touchable ? this.bindEvents() : this.unbindEvents();
     }
   }
 
@@ -136,9 +140,11 @@ CarouselTrack.propTypes = {
   onNext: PropTypes.func.isRequired,
   onPrev: PropTypes.func.isRequired,
   current: PropTypes.number,
+  touchable: PropTypes.bool,
 };
 
 CarouselTrack.defaultProps = {
+  touchable: true,
   current: 0,
 };
 

--- a/components/carousel/carouselTrack.js
+++ b/components/carousel/carouselTrack.js
@@ -67,7 +67,6 @@ class CarouselTrack extends Component {
   }
 
   handleStart(evt) {
-    evt.preventDefault();
     this.isDragging = true;
     // setup element boundaries
     this.resetSlidePosition(this.props.current);

--- a/tests/unit/carousel/__snapshots__/carousel.spec.js.snap
+++ b/tests/unit/carousel/__snapshots__/carousel.spec.js.snap
@@ -21,6 +21,7 @@ exports[`Carousel #render() clicking markers to change pagination 1`] = `
       ‹
     </span>
   }
+  touchable={true}
 >
   <div
     className="ui-carousel"
@@ -29,6 +30,7 @@ exports[`Carousel #render() clicking markers to change pagination 1`] = `
       current={0}
       onNext={[Function]}
       onPrev={[Function]}
+      touchable={true}
     >
       <div
         className="ui-carousel-track"
@@ -166,6 +168,7 @@ exports[`Carousel #render() display markers instead of pagination 1`] = `
       ‹
     </span>
   }
+  touchable={true}
 >
   <div
     className="ui-carousel"
@@ -174,6 +177,7 @@ exports[`Carousel #render() display markers instead of pagination 1`] = `
       current={0}
       onNext={[Function]}
       onPrev={[Function]}
+      touchable={true}
     >
       <div
         className="ui-carousel-track"
@@ -311,6 +315,7 @@ exports[`Carousel #render() hitting next move to first item 1`] = `
       ‹
     </span>
   }
+  touchable={true}
 >
   <div
     className="ui-carousel"
@@ -319,6 +324,7 @@ exports[`Carousel #render() hitting next move to first item 1`] = `
       current={0}
       onNext={[Function]}
       onPrev={[Function]}
+      touchable={true}
     >
       <div
         className="ui-carousel-track"
@@ -444,6 +450,7 @@ exports[`Carousel #render() hitting previous move to last item 1`] = `
       ‹
     </span>
   }
+  touchable={true}
 >
   <div
     className="ui-carousel"
@@ -452,6 +459,7 @@ exports[`Carousel #render() hitting previous move to last item 1`] = `
       current={0}
       onNext={[Function]}
       onPrev={[Function]}
+      touchable={true}
     >
       <div
         className="ui-carousel-track"
@@ -577,6 +585,7 @@ exports[`Carousel #render() prevent swipe after last item 1`] = `
       ‹
     </span>
   }
+  touchable={true}
 >
   <div
     className="ui-carousel"
@@ -585,6 +594,7 @@ exports[`Carousel #render() prevent swipe after last item 1`] = `
       current={0}
       onNext={[Function]}
       onPrev={[Function]}
+      touchable={true}
     >
       <div
         className="ui-carousel-track"
@@ -722,6 +732,7 @@ exports[`Carousel #render() prevent swipe before first item 1`] = `
       ‹
     </span>
   }
+  touchable={true}
 >
   <div
     className="ui-carousel"
@@ -730,6 +741,7 @@ exports[`Carousel #render() prevent swipe before first item 1`] = `
       current={0}
       onNext={[Function]}
       onPrev={[Function]}
+      touchable={true}
     >
       <div
         className="ui-carousel-track"
@@ -872,6 +884,7 @@ exports[`Carousel #render() render with default props and mods 1`] = `
       ‹
     </span>
   }
+  touchable={true}
 >
   <div
     className="ui-carousel ui-carousel_small"
@@ -880,6 +893,7 @@ exports[`Carousel #render() render with default props and mods 1`] = `
       current={0}
       onNext={[Function]}
       onPrev={[Function]}
+      touchable={true}
     >
       <div
         className="ui-carousel-track"
@@ -1005,6 +1019,7 @@ exports[`Carousel #render() show correct pagination info 1`] = `
       ‹
     </span>
   }
+  touchable={true}
 >
   <div
     className="ui-carousel"
@@ -1013,6 +1028,7 @@ exports[`Carousel #render() show correct pagination info 1`] = `
       current={0}
       onNext={[Function]}
       onPrev={[Function]}
+      touchable={true}
     >
       <div
         className="ui-carousel-track"
@@ -1138,6 +1154,7 @@ exports[`Carousel #render() swiping will change the current item 1`] = `
       ‹
     </span>
   }
+  touchable={true}
 >
   <div
     className="ui-carousel"
@@ -1146,6 +1163,7 @@ exports[`Carousel #render() swiping will change the current item 1`] = `
       current={0}
       onNext={[Function]}
       onPrev={[Function]}
+      touchable={true}
     >
       <div
         className="ui-carousel-track"

--- a/tests/unit/carousel/__snapshots__/carouselTrack.spec.js.snap
+++ b/tests/unit/carousel/__snapshots__/carouselTrack.spec.js.snap
@@ -5,6 +5,7 @@ exports[`Carousel Track #render() changing current will move element 1`] = `
   current={3}
   onNext={[MockFunction]}
   onPrev={[MockFunction]}
+  touchable={true}
 >
   <div
     className="ui-carousel-track"
@@ -17,6 +18,7 @@ exports[`Carousel Track #render() changing custom initial item to same dont chan
   current={2}
   onNext={[MockFunction]}
   onPrev={[MockFunction]}
+  touchable={true}
 >
   <div
     className="ui-carousel-track"
@@ -35,6 +37,7 @@ exports[`Carousel Track #render() handle touch events event 1`] = `
       ],
     }
   }
+  touchable={true}
 >
   <div
     className="ui-carousel-track"
@@ -53,6 +56,7 @@ exports[`Carousel Track #render() moving to left will fire next event 1`] = `
     }
   }
   onPrev={[MockFunction]}
+  touchable={true}
 >
   <div
     className="ui-carousel-track"
@@ -71,6 +75,7 @@ exports[`Carousel Track #render() moving to right will fire prev event 1`] = `
       ],
     }
   }
+  touchable={true}
 >
   <div
     className="ui-carousel-track"
@@ -83,6 +88,7 @@ exports[`Carousel Track #render() render with custom initial item 1`] = `
   current={2}
   onNext={[MockFunction]}
   onPrev={[MockFunction]}
+  touchable={true}
 >
   <div
     className="ui-carousel-track"
@@ -95,6 +101,7 @@ exports[`Carousel Track #render() render with default props 1`] = `
   current={0}
   onNext={[MockFunction]}
   onPrev={[MockFunction]}
+  touchable={true}
 >
   <div
     className="ui-carousel-track"
@@ -107,6 +114,7 @@ exports[`Carousel Track #render() small move wont fire prev event 1`] = `
   current={0}
   onNext={[MockFunction]}
   onPrev={[MockFunction]}
+  touchable={true}
 >
   <div
     className="ui-carousel-track"
@@ -119,6 +127,7 @@ exports[`Carousel Track #render() wont move element if touch didnt start 1`] = `
   current={0}
   onNext={[MockFunction]}
   onPrev={[MockFunction]}
+  touchable={true}
 >
   <div
     className="ui-carousel-track"

--- a/tests/unit/carousel/carouselTrack.spec.js
+++ b/tests/unit/carousel/carouselTrack.spec.js
@@ -92,6 +92,38 @@ describe('Carousel Track', () => {
       expect(instance.$elm.style.transform).toEqual('translateX(-600px)');
     });
 
+    it('changing touchable behavior', () => {
+      const renderTree = mount(
+        <CarouselTrack
+          onNext={mockOnNext}
+          onPrev={mockOnPrev}
+        />
+      );
+
+      const instance = renderTree.instance();
+
+      const ctx = {
+        bindEvents: jest.fn(),
+        unbindEvents: jest.fn(),
+        resetSlidePosition: jest.fn(),
+        props: {
+          touchable: false,
+        },
+      };
+
+      instance.componentWillReceiveProps.call(ctx, { touchable: true });
+
+      expect(ctx.bindEvents).toHaveBeenCalledTimes(1);
+      expect(ctx.unbindEvents).toHaveBeenCalledTimes(0);
+
+      ctx.props.touchable = true;
+
+      instance.componentWillReceiveProps.call(ctx, { touchable: false });
+
+      expect(ctx.bindEvents).toHaveBeenCalledTimes(1);
+      expect(ctx.unbindEvents).toHaveBeenCalledTimes(1);
+    });
+
     it('small move wont fire prev event', () => {
       const renderTree = mount(
         <CarouselTrack


### PR DESCRIPTION
# What does this PR do:

   Added ability to use or not use touch events for track of carousel

![selection_059](https://user-images.githubusercontent.com/10462372/33376578-3d70abd2-d51f-11e7-84f9-350d5ad1253d.png)


# Where should the reviewer start:

    Diff
