### PR TITLE
Fix sliding panel overlay z-index

### DIFF
--- a/themes/_default.yaml
+++ b/themes/_default.yaml
@@ -521,7 +521,7 @@ sliding-panel:
   overlay:
     background-color: "rgba(var(--tx-generic-color-primary-dark-rgb), .65)"
     position: "fixed"
-    z-index: "3"
+    z-index: "999"
   panel:
     background-color: "var(--tx-generic-color-blank)"
     bottom: "0"


### PR DESCRIPTION
# What does this PR do:

    This PR fixes sliding panel overlay z-index, because of `feedback` button z-index (`fedback` button should not overlap sliding panel)

# Where should the reviewer start:

    Look at diff
