### PR TITLE
fixed css for autocomplete and input

### DIFF
--- a/components/autoComplete/autoComplete.scss
+++ b/components/autoComplete/autoComplete.scss
@@ -12,6 +12,7 @@
   margin-top: -2px;
   max-height: 300px;
   overflow-x: overlay;
+  overflow-y: auto;
   position: absolute;
   right: 0;
   top: 100%;

--- a/components/input/input.scss
+++ b/components/input/input.scss
@@ -52,4 +52,8 @@
   &:hover {
     border-color: var(--tx-input-border-hover-color);
   }
+
+  &::-ms-clear {
+    display: none;
+  }
 }


### PR DESCRIPTION
# What does this PR do:
* fixed `overflow-y` for autocomplete popunder (IE11 and Firefox)
![selection_092](https://user-images.githubusercontent.com/12394253/34110616-39969b72-e418-11e7-96cf-c93ebe36e452.png)

* removed cross in input (IE11)
![selection_093](https://user-images.githubusercontent.com/12394253/34110618-3e4e9502-e418-11e7-9247-a66e832de3b7.png)

# Where should the reviewer start:
* diff