### PR TITLE
since edge does not fully support css variables load the css-vars-pol…

### DIFF
--- a/styleguide.html
+++ b/styleguide.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <link rel="stylesheet" href="/ui-bundle.css" data-cssvars />
     <link rel="stylesheet" href="/theme.css" />
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.find,String.prototype.repeat,Array.prototype.keys,Array.prototype.includes"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.find,String.prototype.repeat,Array.prototype.keys"></script>
     <script src="https://maps.googleapis.com/maps/api/js?libraries=places,visualization&v=3.27&key=AIzaSyAqvSFBj-lPSA8BsEbSoqU7dzRlQxPUf8I"></script>
     <script>
       (function () {

--- a/styleguide.html
+++ b/styleguide.html
@@ -4,13 +4,13 @@
     <meta charset="utf-8">
     <link rel="stylesheet" href="/ui-bundle.css" data-cssvars />
     <link rel="stylesheet" href="/theme.css" />
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.find,String.prototype.repeat,Array.prototype.keys"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.find,String.prototype.repeat,Array.prototype.keys,Array.prototype.includes"></script>
     <script src="https://maps.googleapis.com/maps/api/js?libraries=places,visualization&v=3.27&key=AIzaSyAqvSFBj-lPSA8BsEbSoqU7dzRlQxPUf8I"></script>
     <script>
       (function () {
         'use strict';
 
-        if (window.CSS && CSS.supports('color', 'var(--primary)')) {
+        if (window.CSS && CSS.supports('color', 'var(--primary)') && navigator.userAgent.indexOf('Edge/15') === -1) {
           return;
         }
 


### PR DESCRIPTION
# What does this PR do:

- since edge does not fully support css variables load the css-vars-polyfill in it
- fixes #243 

# Where should the reviewer start:

- diff
