### PR TITLE
Collapse fix

### DIFF
--- a/components/collapse/collapse.js
+++ b/components/collapse/collapse.js
@@ -6,7 +6,7 @@ import React, {
   isValidElement,
 } from 'react';
 
-import { getClassNamesWithMods, ejectOtherProps } from '../_helpers';
+import { getClassNamesWithMods, getDataAttributes } from '../_helpers';
 
 const getNormalizedActiveKey = ({ defaultActiveKey, activeKey }) => {
   if (typeof activeKey === 'undefined') {
@@ -92,9 +92,8 @@ class Collapse extends Component {
       isAccordion,
       children,
       mods = [],
+      dataAttrs,
     } = this.props;
-
-    const otherProps = ejectOtherProps(this.props, Collapse.propTypes);
 
     if (Children.count(children) === 0) {
       return null;
@@ -105,7 +104,7 @@ class Collapse extends Component {
     };
 
     return (
-      <div {...otherProps} className={getClassNamesWithMods('ui-collapse', mods, collapseMods)}>
+      <div {...getDataAttributes(dataAttrs)} className={getClassNamesWithMods('ui-collapse', mods, collapseMods)}>
         {this.renderItems()}
       </div>
     );
@@ -151,6 +150,10 @@ Collapse.propTypes = {
    * Specify a function that will be called when a user click on CollapseItem
    */
   onChange: PropTypes.func,
+  /**
+   * Data attributes. You can use it to set up any custom data-* attribute
+   */
+  dataAttrs: PropTypes.object,
 };
 
 Collapse.defaultProps = {

--- a/components/collapse/collapse.js
+++ b/components/collapse/collapse.js
@@ -5,6 +5,7 @@ import React, {
   cloneElement,
   isValidElement,
 } from 'react';
+import classnames from 'classnames';
 
 import { getClassNamesWithMods, getDataAttributes } from '../_helpers';
 
@@ -89,6 +90,7 @@ class Collapse extends Component {
 
   render() {
     const {
+      className,
       isAccordion,
       children,
       mods = [],
@@ -103,8 +105,10 @@ class Collapse extends Component {
       accordion: isAccordion,
     };
 
+    const classNames = classnames(getClassNamesWithMods('ui-collapse', mods, collapseMods), className);
+
     return (
-      <div {...getDataAttributes(dataAttrs)} className={getClassNamesWithMods('ui-collapse', mods, collapseMods)}>
+      <div {...getDataAttributes(dataAttrs)} className={classNames}>
         {this.renderItems()}
       </div>
     );
@@ -154,6 +158,10 @@ Collapse.propTypes = {
    * Data attributes. You can use it to set up any custom data-* attribute
    */
   dataAttrs: PropTypes.object,
+  /**
+   * Custom className.
+   */
+  className: PropTypes.string,
 };
 
 Collapse.defaultProps = {

--- a/components/collapse/collapseItem.js
+++ b/components/collapse/collapseItem.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import classnames from 'classnames';
 
 import { getClassNamesWithMods, getDataAttributes } from '../_helpers';
 
@@ -17,6 +18,7 @@ class CollapseItem extends Component {
 
   render() {
     const {
+      className,
       id,
       isActive,
       title,
@@ -25,13 +27,17 @@ class CollapseItem extends Component {
       dataAttrs,
       labelDataAttrs,
     } = this.props;
+
     const mods = {
       active: isActive,
     };
+
+    const classNames = classnames(getClassNamesWithMods('ui-collapse-item', mods), className);
+
     return (
       <div
         {...getDataAttributes(dataAttrs)}
-        className={getClassNamesWithMods('ui-collapse-item', mods)}
+        className={classNames}
       >
         <button
           {...getDataAttributes(labelDataAttrs)}
@@ -94,6 +100,10 @@ CollapseItem.propTypes = {
    * Data attributes for header label. You can use it to set up any custom data-* attribute
    */
   labelDataAttrs: PropTypes.object,
+  /**
+   * Custom className.
+   */
+  className: PropTypes.string,
 };
 
 CollapseItem.defaultProps = {

--- a/components/collapse/collapseItem.js
+++ b/components/collapse/collapseItem.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
-import { getClassNamesWithMods } from '../_helpers';
+import { getClassNamesWithMods, getDataAttributes } from '../_helpers';
 
 /**
  * Collapse item component
@@ -21,18 +21,20 @@ class CollapseItem extends Component {
       isActive,
       title,
       children,
-      onClick, // eslint-disable-line no-unused-vars
       iconPosition,
-      labelProps = {},
-      ...otherProps
+      dataAttrs,
+      labelDataAttrs,
     } = this.props;
     const mods = {
       active: isActive,
     };
     return (
-      <div {...otherProps} className={getClassNamesWithMods('ui-collapse-item', mods)}>
+      <div
+        {...getDataAttributes(dataAttrs)}
+        className={getClassNamesWithMods('ui-collapse-item', mods)}
+      >
         <button
-          {...labelProps}
+          {...getDataAttributes(labelDataAttrs)}
           aria-controls={id}
           aria-expanded={isActive}
           className={
@@ -85,9 +87,13 @@ CollapseItem.propTypes = {
    */
   iconPosition: PropTypes.oneOf(['right', 'left']),
   /**
-   * Specify props for label
+   * Data attributes. You can use it to set up any custom data-* attribute
    */
-  labelProps: PropTypes.object,
+  dataAttrs: PropTypes.object,
+  /**
+   * Data attributes for header label. You can use it to set up any custom data-* attribute
+   */
+  labelDataAttrs: PropTypes.object,
 };
 
 CollapseItem.defaultProps = {

--- a/components/collapse/collapseItem.scss
+++ b/components/collapse/collapseItem.scss
@@ -31,16 +31,20 @@
       content: '\25bc\0020';
     }
   }
-}
 
-.ui-collapse__label--icon_position_right {
-  flex-direction: row-reverse;
-  justify-content: space-between;
+  &::-moz-focus-inner {
+    border: 0;
+  }
 }
 
 .ui-collapse__label-icon {
   flex-shrink: 0;
   margin-right: 10px;
+
+  .ui-collapse__label--icon_position_right & {
+    margin-left: auto;
+    order: 1;
+  }
 
   &:before {
     color: var(--tx-collapse-item-label-icon-color);


### PR DESCRIPTION
# What does this PR do:
* fixed styles for firefox and safari 9 for collapse and collapseItem components
* removed otherProps and added dataAttrs to collapse and collapseItem components
* added className prop to collapse and collapseItem components
# Where should the reviewer start:
* diff
#### safari before
![selection_099](https://user-images.githubusercontent.com/12394253/34210660-b939dec6-e5a7-11e7-95f3-12f96697103d.png)
#### safari after
![selection_098](https://user-images.githubusercontent.com/12394253/34210672-c0550c62-e5a7-11e7-8d8d-8844fc0ba678.png)
#### firefox before
![selection_100](https://user-images.githubusercontent.com/12394253/34210726-f0f1d436-e5a7-11e7-9c69-20d67050f272.png)
