### PR TITLE
Fix styleguide.config.js for Windows

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   title: 'Travix styleguide',
   assetsDir: 'dist',
@@ -13,7 +15,7 @@ module.exports = {
       rules: [
         {
           test: /\.js?$/,
-          include: __dirname + '/components',
+          include: path.join(__dirname, 'components'),
           use: 'babel-loader',
         },
       ],


### PR DESCRIPTION
# What does this PR do:

Fix error when running 'npm run styleguide-build' on Windows

# Where should the reviewer start:

Try to run 'npm run styleguide-build'
