### PR TITLE
added className and dataAttrs props and removed dead prop

### DIFF
--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -1,6 +1,7 @@
+import classnames from "classnames";
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { getClassNamesWithMods } from '../_helpers';
+import { getClassNamesWithMods, getDataAttributes } from '../_helpers';
 
 export default class Tooltip extends Component {
   linkChild = (ref) => {
@@ -23,18 +24,28 @@ export default class Tooltip extends Component {
   }
 
   render() {
-    const { axisOffsetX, axisOffsetY, align, width, height, active, position } = this.props;
+    const {
+      active,
+      align,
+      axisOffsetX,
+      axisOffsetY,
+      className,
+      dataAttrs,
+      height,
+      position,
+      width,
+    } = this.props;
 
     const mods = this.props.mods
       ? this.props.mods.slice()
       : [];
 
-    const className = getClassNamesWithMods('ui-tooltip', [
+    const classNames = classnames(className, getClassNamesWithMods('ui-tooltip', [
       ...mods,
       active ? 'active' : 'inactive',
       position,
       align,
-    ]);
+    ]));
 
     let styles = {
       width,
@@ -49,7 +60,7 @@ export default class Tooltip extends Component {
     }
 
     return (
-      <div className={className} ref={this.linkChild} style={styles}>
+      <div className={classNames} ref={this.linkChild} style={styles} {...getDataAttributes(dataAttrs)}>
         {this.renderCloseButtonBlock()}
         {this.props.children}
       </div>
@@ -84,6 +95,18 @@ Tooltip.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.string,
+  ]),
+  /**
+   * Custom className(s) to be concatenated with the default ones
+   * on the component's root element
+   */
+  className: PropTypes.string,
+  /**
+   * Data attribute. You can use it to set up GTM key or any custom data-* attribute
+   */
+  dataAttrs: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.object,
   ]),
   /**
    * The height of the component (px)
@@ -128,8 +151,8 @@ Tooltip.defaultProps = {
   active: false,
   align: 'center',
   children: '',
+  dataAttrs: null,
   height: 'auto',
-  oppositeAxisOffset: '0',
   position: 'top',
   showCloseButton: false,
   triggerAction: 'click',

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -40,7 +40,7 @@ export default class Tooltip extends Component {
       ? this.props.mods.slice()
       : [];
 
-    const classNames = classnames(className, getClassNamesWithMods('ui-tooltip', [
+    const classes = classnames(className, getClassNamesWithMods('ui-tooltip', [
       ...mods,
       active ? 'active' : 'inactive',
       position,
@@ -60,7 +60,7 @@ export default class Tooltip extends Component {
     }
 
     return (
-      <div className={classNames} ref={this.linkChild} style={styles} {...getDataAttributes(dataAttrs)}>
+      <div className={classes} ref={this.linkChild} style={styles} {...getDataAttributes(dataAttrs)}>
         {this.renderCloseButtonBlock()}
         {this.props.children}
       </div>

--- a/components/tooltip/tooltip.md
+++ b/components/tooltip/tooltip.md
@@ -98,6 +98,8 @@ Also check OverlayTrigger specification.
         elemToToggle={
           <Tooltip
             align={state.align}
+            className={'costumClass'}
+            dataAttrs={{'gtm-id': 'tooltip-gtm'}}
             margin={state.customMargin ? '22px' : undefined}
             axisOffsetX={state.customOppositeOffset ? '-50%' : undefined}
             axisOffsetY={state.customOppositeOffset ? '-100px' : undefined}

--- a/tests/unit/tooltip/__snapshots__/tooltip.render.spec.js.snap
+++ b/tests/unit/tooltip/__snapshots__/tooltip.render.spec.js.snap
@@ -6,8 +6,8 @@ exports[`Tooltip: render should render active tooltip with all passed props 1`] 
   align="center"
   axisOffsetX="100px"
   axisOffsetY="110px"
+  dataAttrs={null}
   height="70px"
-  oppositeAxisOffset="0"
   position="right"
   showCloseButton={true}
   triggerAction="hover"


### PR DESCRIPTION
# What does this PR do:

- Adds the possibility to pass className and dataAttrs to the container of the tooltip component
- Removes dead prop
- unit test were updated

# Where should the reviewer start:

    diffs in Tooltip.js, 