### PR TITLE
Extend spinner using children

### DIFF
--- a/components/spinner/spinner.js
+++ b/components/spinner/spinner.js
@@ -4,10 +4,10 @@ import React from 'react';
 import { getClassNamesWithMods } from '../_helpers';
 
 /**
- * General Spinner component. Use when you need spinner
+ * General Spinner component.
  */
 function Spinner(props) {
-  const { size } = props;
+  const { size, children, loading, loadingMessage, transparent } = props;
   const mods = props.mods ? props.mods.slice() : [];
 
   mods.push(`size_${size}`);
@@ -15,7 +15,7 @@ function Spinner(props) {
   const className = getClassNamesWithMods('ui-spinner', mods);
 
   /* eslint-disable max-len */
-  return (
+  const spinner = (
     <div className={className}>
       <svg
         version="1.1"
@@ -112,11 +112,38 @@ function Spinner(props) {
       </svg>
     </div>
   );
+
+  if (!children) {
+    return spinner;
+  }
+
+  let loadingSection = null;
+
+  if (loading) {
+    loadingSection = (
+      <div className="ui-spinner__loading-section">
+        {spinner}
+        <span className="ui-spinner__loading-text"> {loadingMessage} </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={getClassNamesWithMods('ui-spinner__wrapper', { loading, transparent })}>
+      {loadingSection}
+      <div className="ui-spinner__content">
+        {children}
+      </div>
+    </div>
+  );
   /* eslint-enable max-len */
 }
 
 Spinner.defaultProps = {
   size: 'm',
+  loading: true,
+  loadingMessage: '',
+  transparent: false,
 };
 
 Spinner.propTypes = {
@@ -124,12 +151,26 @@ Spinner.propTypes = {
    * You can provide set of custom modifications.
    */
   mods: PropTypes.arrayOf(PropTypes.string),
-
   /**
    * Spinner size.
    */
   size: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
-
+  /**
+   * You can pass child component(s) which will be wrapped into the loading section.
+   */
+  children: PropTypes.node,
+  /**
+   * When used with children, determines whether to show spinner or content.
+   */
+  loading: PropTypes.bool,
+  /**
+   * Simple text to be shown next to the spinner.
+   */
+  loadingMessage: PropTypes.node,
+  /**
+   * Enable translucency for the loading section. You will partially see the content while loading.
+   */
+  transparent: PropTypes.bool,
 };
 
 export default Spinner;

--- a/components/spinner/spinner.js
+++ b/components/spinner/spinner.js
@@ -1,6 +1,7 @@
 // Imports
 import PropTypes from 'prop-types';
 import React from 'react';
+import classnames from 'classnames';
 import { getClassNamesWithMods } from '../_helpers';
 
 /**
@@ -129,7 +130,14 @@ function Spinner(props) {
   }
 
   return (
-    <div className={getClassNamesWithMods('ui-spinner__wrapper', { loading, transparent, [wrapperClassName]: wrapperClassName })}>
+    <div
+      className={
+        classnames(
+          getClassNamesWithMods('ui-spinner__wrapper', { loading, transparent }),
+          wrapperClassName,
+        )
+      }
+    >
       {loadingSection}
       <div className="ui-spinner__content">
         {children}

--- a/components/spinner/spinner.js
+++ b/components/spinner/spinner.js
@@ -7,7 +7,7 @@ import { getClassNamesWithMods } from '../_helpers';
  * General Spinner component.
  */
 function Spinner(props) {
-  const { size, children, loading, loadingMessage, transparent } = props;
+  const { size, children, loading, loadingMessage, transparent, wrapperClassName } = props;
   const mods = props.mods ? props.mods.slice() : [];
 
   mods.push(`size_${size}`);
@@ -129,7 +129,7 @@ function Spinner(props) {
   }
 
   return (
-    <div className={getClassNamesWithMods('ui-spinner__wrapper', { loading, transparent })}>
+    <div className={getClassNamesWithMods('ui-spinner__wrapper', { loading, transparent, [wrapperClassName]: wrapperClassName })}>
       {loadingSection}
       <div className="ui-spinner__content">
         {children}
@@ -140,21 +140,14 @@ function Spinner(props) {
 }
 
 Spinner.defaultProps = {
-  size: 'm',
   loading: true,
   loadingMessage: '',
+  size: 'm',
   transparent: false,
+  wrapperClassName: '',
 };
 
 Spinner.propTypes = {
-  /**
-   * You can provide set of custom modifications.
-   */
-  mods: PropTypes.arrayOf(PropTypes.string),
-  /**
-   * Spinner size.
-   */
-  size: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
   /**
    * You can pass child component(s) which will be wrapped into the loading section.
    */
@@ -168,9 +161,21 @@ Spinner.propTypes = {
    */
   loadingMessage: PropTypes.node,
   /**
+   * You can provide set of custom modifications.
+   */
+  mods: PropTypes.arrayOf(PropTypes.string),
+  /**
+   * Spinner size.
+   */
+  size: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
+  /**
    * Enable translucency for the loading section. You will partially see the content while loading.
    */
   transparent: PropTypes.bool,
+  /**
+   * Custom className that can be passed to root wrapper container.
+   */
+  wrapperClassName: PropTypes.string,
 };
 
 export default Spinner;

--- a/components/spinner/spinner.js
+++ b/components/spinner/spinner.js
@@ -134,7 +134,7 @@ function Spinner(props) {
       className={
         classnames(
           getClassNamesWithMods('ui-spinner__wrapper', { loading, transparent }),
-          wrapperClassName,
+          wrapperClassName
         )
       }
     >

--- a/components/spinner/spinner.md
+++ b/components/spinner/spinner.md
@@ -1,9 +1,38 @@
 Spinner:
 
+    initialState = {
+      isLoadingEnabled: true,
+      isTransparent: false,
+    };
+
     <div>
-      <Spinner size="xs"/><br/><br/>
-      <Spinner size="s"/><br/><br/>
-      <Spinner size="m"/><br/><br/>
-      <Spinner size="l"/><br/><br/>
-      <Spinner size="xl"/><br/><br/>
+      <div style={{ marginBottom: '20px' }}>
+        <Checkbox
+          checked={state.isLoadingEnabled}
+          name="isLoadingEnabled"
+          onChange={() => setState({ isLoadingEnabled: !state.isLoadingEnabled })}
+        >
+          Enable loading
+        </Checkbox>
+        <Checkbox
+          checked={state.isTransparent}
+          name="isTransparent"
+          onChange={() => setState({ isTransparent: !state.isTransparent })}
+        >
+          Enable transparency
+        </Checkbox>
+      </div>
+      <div>
+        <Spinner size="xs"/><br/><br/>
+        <Spinner size="s"/><br/><br/>
+        <Spinner size="m"/><br/><br/>
+        <Spinner size="l"/><br/><br/>
+        <Spinner size="xl"/><br/><br/>
+
+        Spinner with children:
+
+        <Spinner size="s" loadingMessage='Loading' loading={state.isLoadingEnabled} transparent={state.isTransparent}>
+          At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat.
+        </Spinner>
+      </div>
     </div>

--- a/components/spinner/spinner.scss
+++ b/components/spinner/spinner.scss
@@ -125,7 +125,7 @@
   color: var(--tx-generic-color-primary);
   font-family: var(--tx-generic-font-primary-font-family);
   font-size: 19px;
-  font-weight: bold;
+  font-weight: var(--tx-generic-font-primary-weight-semibold);
   margin-left: 8px;
 }
 

--- a/components/spinner/spinner.scss
+++ b/components/spinner/spinner.scss
@@ -123,7 +123,7 @@
 
 .ui-spinner__loading-text {
   color: var(--tx-generic-color-primary);
-  font-family: var(--tx-generic-font-primary-font-family);
+  font-family: var(--tx-generic-font-primary-font-family), var(--tx-generic-font-primary-generic-family);
   font-size: 19px;
   font-weight: var(--tx-generic-font-primary-weight-semibold);
   margin-left: 8px;

--- a/components/spinner/spinner.scss
+++ b/components/spinner/spinner.scss
@@ -131,6 +131,7 @@
 
 .ui-spinner__wrapper {
   border-radius: var(--tx-spinner-wrapper-border-radius);
+  overflow: hidden;
   position: relative;
 }
 

--- a/components/spinner/spinner.scss
+++ b/components/spinner/spinner.scss
@@ -118,19 +118,19 @@
   justify-content: center;
   position: absolute;
   width: 100%;
-  z-index: var(--tx-spinner-wrapper-z-index);
+  z-index: 100;
 }
 
 .ui-spinner__loading-text {
   color: var(--tx-generic-color-primary);
   font-family: var(--tx-generic-font-primary-font-family);
-  font-size: var(--tx-spinner-text-font-size);
+  font-size: 19px;
   font-weight: bold;
   margin-left: 8px;
 }
 
 .ui-spinner__wrapper {
-  border-radius: var(--tx-spinner-wrapper-border-radius);
+  border-radius: 8px;
   overflow: hidden;
   position: relative;
 }
@@ -149,12 +149,12 @@
     right: 0;
     top: 0;
     transition: all 0.3s;
-    z-index: var(--tx-spinner-content-z-index);
+    z-index: 99;
   }
 }
 
 .ui-spinner__wrapper_transparent {
   .ui-spinner__content:before {
-    opacity: var(--tx-spinner-wrapper-transparent-opacity);
+    opacity: 0.5;
   }
 }

--- a/components/spinner/spinner.scss
+++ b/components/spinner/spinner.scss
@@ -110,3 +110,50 @@
     transform: rotate(360deg);
   }
 }
+
+.ui-spinner__loading-section {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  position: absolute;
+  width: 100%;
+  z-index: var(--tx-spinner-wrapper-z-index);
+}
+
+.ui-spinner__loading-text {
+  color: var(--tx-generic-color-primary);
+  font-family: var(--tx-generic-font-primary-font-family);
+  font-size: var(--tx-spinner-text-font-size);
+  font-weight: bold;
+  margin-left: 8px;
+}
+
+.ui-spinner__wrapper {
+  border-radius: var(--tx-spinner-wrapper-border-radius);
+  position: relative;
+}
+
+.ui-spinner__content {
+  transition: all 0.2s ease-in-out;
+}
+
+.ui-spinner__wrapper_loading {
+  .ui-spinner__content:before {
+    background: var(--tx-generic-color-secondary-light);
+    bottom: 0;
+    content: "";
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    transition: all 0.3s;
+    z-index: var(--tx-spinner-content-z-index);
+  }
+}
+
+.ui-spinner__wrapper_transparent {
+  .ui-spinner__content:before {
+    opacity: var(--tx-spinner-wrapper-transparent-opacity);
+  }
+}

--- a/tests/unit/spinner/__snapshots__/spinner.spec.js.snap
+++ b/tests/unit/spinner/__snapshots__/spinner.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Spinner #render() should handle custom className passed to the wrapper 1`] = `
 <div
-  className="ui-spinner__wrapper ui-spinner__wrapper_loading ui-spinner__wrapper_my-custom-class"
+  className="ui-spinner__wrapper ui-spinner__wrapper_loading my-custom-class"
 >
   <div
     className="ui-spinner__loading-section"

--- a/tests/unit/spinner/__snapshots__/spinner.spec.js.snap
+++ b/tests/unit/spinner/__snapshots__/spinner.spec.js.snap
@@ -1,5 +1,124 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Spinner #render() should handle custom className passed to the wrapper 1`] = `
+<div
+  className="ui-spinner__wrapper ui-spinner__wrapper_loading ui-spinner__wrapper_my-custom-class"
+>
+  <div
+    className="ui-spinner__loading-section"
+  >
+    <div
+      className="ui-spinner ui-spinner_size_m"
+    >
+      <svg
+        version="1.1"
+        viewBox="0 0 80 80"
+        x="0px"
+        xlinkHref="http://www.w3.org/1999/xlink"
+        xmlSpace="preserve"
+        xmlns="http://www.w3.org/2000/svg"
+        y="0px"
+      >
+        <g>
+          <g>
+            <circle
+              clipRule="evenodd"
+              cx="40"
+              cy="40"
+              fillRule="evenodd"
+              r="34.3"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M39.9,33.1c0.5-5.4-1.5-10.4-5.2-14.9c6.1-2.1,7.6-1.5,8.6,3.8c0.5,2.9,0.4,6,0.1,9c-0.1,0.9-0.3,1.8-0.7,2.7c-0.8-0.3-1.8-0.6-2.7-0.6H39.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M46.6,41.9c5.3,2,10.6,2.1,16-0.3c0.8,5.6-0.3,7-5.4,6.9c-4.6,0-8.5-1.6-12-4.1C45.9,43.7,46.3,42.8,46.6,41.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M44.3,45.4c3.1,4.5,7.2,7.7,13.2,8.9c-3.2,5.1-5.1,5.5-9.2,2.1c-3.2-2.6-5.3-5.9-6.5-9.8C42.7,46.4,43.5,46,44.3,45.4z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M40.1,46.9c-0.1,5.6,1.3,10.4,5.3,14.5c-5.6,2.6-7.2,2-8.6-3.3c-0.5-1.8-0.8-3.7-0.6-5.6c0.2-2,0.6-4.1,1.1-6.2c0.8,0.3,1.7,0.5,2.7,0.5H40.1z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M36,45.5c-3.5,4.3-5,9.2-4.7,14.8c-5.7-1.2-6.8-2.7-4.9-7.3c1.1-2.5,2.6-4.8,4.4-6.8c0.9-1,2-1.9,3.3-2.8C34.6,44.3,35.2,45,36,45.5z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M33.5,42.1c-5.6,1.5-9.8,4.5-12.8,9.5c-4-4.2-3.9-6.4,0.6-9.1c1.6-1,3.4-1.9,5.2-2.2c2.2-0.4,4.4-0.6,6.6-0.8l0,0.5C33.1,40.7,33.2,41.5,33.5,42.1z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M33.5,37.9c-3.7-1.5-7.1-1.4-16,0c-1-4.9,0.3-6.5,5-6.6c4.7,0,8.8,1.6,12.4,4.1C34.2,36.2,33.8,37,33.5,37.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M35.8,34.6c-3-4.7-7.3-7.8-13.2-9c3.4-5.2,5.2-5.5,9.5-1.9c3.2,2.6,5.2,5.9,6.5,9.6C37.5,33.5,36.6,34,35.8,34.6z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M48,34.8c-0.5,0.7-1.4,1.1-2.1,1.6c-0.5-0.8-1.1-1.5-1.8-2c3.5-4.4,5.2-9.2,4.6-14.9c5.7,0.8,7.1,2.7,5.1,7.1C52.3,29.6,50,32.2,48,34.8z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M46.9,40c0-0.8-0.1-1.5-0.4-2.2c5.8-1.6,10-4.7,13.1-9.6c4.4,6.1,3.2,6.4-1.3,9.5c-1.5,1-3.3,1.7-5,2c-2.1,0.4-4.2,0.6-6.4,0.8L46.9,40z"
+              fillRule="evenodd"
+            />
+          </g>
+          <circle
+            className="ui-spinner_lighter"
+            clipRule="evenodd"
+            cx="40"
+            cy="40"
+            fillRule="evenodd"
+            r="36"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeMiterlimit="10"
+            strokeWidth="8"
+          />
+        </g>
+      </svg>
+    </div>
+    <span
+      className="ui-spinner__loading-text"
+    >
+       
+       
+    </span>
+  </div>
+  <div
+    className="ui-spinner__content"
+  >
+    Testing custom class...
+  </div>
+</div>
+`;
+
 exports[`Spinner #render() should handle non-loading mode 1`] = `
 <div
   className="ui-spinner__wrapper"

--- a/tests/unit/spinner/__snapshots__/spinner.spec.js.snap
+++ b/tests/unit/spinner/__snapshots__/spinner.spec.js.snap
@@ -1,206 +1,494 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Spinner #render() should handle non-loading mode 1`] = `
+<div
+  className="ui-spinner__wrapper"
+>
+  <div
+    className="ui-spinner__content"
+  >
+    Some content
+  </div>
+</div>
+`;
+
 exports[`Spinner #render() should not modify mods 1`] = `
 <div
-  className="ui-spinner ui-spinner_test ui-spinner_size_xs"
+  className="ui-spinner__wrapper ui-spinner__wrapper_loading"
 >
-  <svg
-    version="1.1"
-    viewBox="0 0 80 80"
-    x="0px"
-    xlinkHref="http://www.w3.org/1999/xlink"
-    xmlSpace="preserve"
-    xmlns="http://www.w3.org/2000/svg"
-    y="0px"
+  <div
+    className="ui-spinner__loading-section"
   >
-    <g>
-      <g>
-        <circle
-          clipRule="evenodd"
-          cx="40"
-          cy="40"
-          fillRule="evenodd"
-          r="34.3"
-        />
-        <path
-          className="ui-spinner_darker"
-          clipRule="evenodd"
-          d="M39.9,33.1c0.5-5.4-1.5-10.4-5.2-14.9c6.1-2.1,7.6-1.5,8.6,3.8c0.5,2.9,0.4,6,0.1,9c-0.1,0.9-0.3,1.8-0.7,2.7c-0.8-0.3-1.8-0.6-2.7-0.6H39.9z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_dark"
-          clipRule="evenodd"
-          d="M46.6,41.9c5.3,2,10.6,2.1,16-0.3c0.8,5.6-0.3,7-5.4,6.9c-4.6,0-8.5-1.6-12-4.1C45.9,43.7,46.3,42.8,46.6,41.9z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_dark"
-          clipRule="evenodd"
-          d="M44.3,45.4c3.1,4.5,7.2,7.7,13.2,8.9c-3.2,5.1-5.1,5.5-9.2,2.1c-3.2-2.6-5.3-5.9-6.5-9.8C42.7,46.4,43.5,46,44.3,45.4z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_dark"
-          clipRule="evenodd"
-          d="M40.1,46.9c-0.1,5.6,1.3,10.4,5.3,14.5c-5.6,2.6-7.2,2-8.6-3.3c-0.5-1.8-0.8-3.7-0.6-5.6c0.2-2,0.6-4.1,1.1-6.2c0.8,0.3,1.7,0.5,2.7,0.5H40.1z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_dark"
-          clipRule="evenodd"
-          d="M36,45.5c-3.5,4.3-5,9.2-4.7,14.8c-5.7-1.2-6.8-2.7-4.9-7.3c1.1-2.5,2.6-4.8,4.4-6.8c0.9-1,2-1.9,3.3-2.8C34.6,44.3,35.2,45,36,45.5z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_dark"
-          clipRule="evenodd"
-          d="M33.5,42.1c-5.6,1.5-9.8,4.5-12.8,9.5c-4-4.2-3.9-6.4,0.6-9.1c1.6-1,3.4-1.9,5.2-2.2c2.2-0.4,4.4-0.6,6.6-0.8l0,0.5C33.1,40.7,33.2,41.5,33.5,42.1z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_darker"
-          clipRule="evenodd"
-          d="M33.5,37.9c-3.7-1.5-7.1-1.4-16,0c-1-4.9,0.3-6.5,5-6.6c4.7,0,8.8,1.6,12.4,4.1C34.2,36.2,33.8,37,33.5,37.9z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_darker"
-          clipRule="evenodd"
-          d="M35.8,34.6c-3-4.7-7.3-7.8-13.2-9c3.4-5.2,5.2-5.5,9.5-1.9c3.2,2.6,5.2,5.9,6.5,9.6C37.5,33.5,36.6,34,35.8,34.6z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_dark"
-          clipRule="evenodd"
-          d="M48,34.8c-0.5,0.7-1.4,1.1-2.1,1.6c-0.5-0.8-1.1-1.5-1.8-2c3.5-4.4,5.2-9.2,4.6-14.9c5.7,0.8,7.1,2.7,5.1,7.1C52.3,29.6,50,32.2,48,34.8z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_dark"
-          clipRule="evenodd"
-          d="M46.9,40c0-0.8-0.1-1.5-0.4-2.2c5.8-1.6,10-4.7,13.1-9.6c4.4,6.1,3.2,6.4-1.3,9.5c-1.5,1-3.3,1.7-5,2c-2.1,0.4-4.2,0.6-6.4,0.8L46.9,40z"
-          fillRule="evenodd"
-        />
-      </g>
-      <circle
-        className="ui-spinner_lighter"
-        clipRule="evenodd"
-        cx="40"
-        cy="40"
-        fillRule="evenodd"
-        r="36"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeMiterlimit="10"
-        strokeWidth="8"
-      />
-    </g>
-  </svg>
+    <div
+      className="ui-spinner ui-spinner_test ui-spinner_size_xs"
+    >
+      <svg
+        version="1.1"
+        viewBox="0 0 80 80"
+        x="0px"
+        xlinkHref="http://www.w3.org/1999/xlink"
+        xmlSpace="preserve"
+        xmlns="http://www.w3.org/2000/svg"
+        y="0px"
+      >
+        <g>
+          <g>
+            <circle
+              clipRule="evenodd"
+              cx="40"
+              cy="40"
+              fillRule="evenodd"
+              r="34.3"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M39.9,33.1c0.5-5.4-1.5-10.4-5.2-14.9c6.1-2.1,7.6-1.5,8.6,3.8c0.5,2.9,0.4,6,0.1,9c-0.1,0.9-0.3,1.8-0.7,2.7c-0.8-0.3-1.8-0.6-2.7-0.6H39.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M46.6,41.9c5.3,2,10.6,2.1,16-0.3c0.8,5.6-0.3,7-5.4,6.9c-4.6,0-8.5-1.6-12-4.1C45.9,43.7,46.3,42.8,46.6,41.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M44.3,45.4c3.1,4.5,7.2,7.7,13.2,8.9c-3.2,5.1-5.1,5.5-9.2,2.1c-3.2-2.6-5.3-5.9-6.5-9.8C42.7,46.4,43.5,46,44.3,45.4z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M40.1,46.9c-0.1,5.6,1.3,10.4,5.3,14.5c-5.6,2.6-7.2,2-8.6-3.3c-0.5-1.8-0.8-3.7-0.6-5.6c0.2-2,0.6-4.1,1.1-6.2c0.8,0.3,1.7,0.5,2.7,0.5H40.1z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M36,45.5c-3.5,4.3-5,9.2-4.7,14.8c-5.7-1.2-6.8-2.7-4.9-7.3c1.1-2.5,2.6-4.8,4.4-6.8c0.9-1,2-1.9,3.3-2.8C34.6,44.3,35.2,45,36,45.5z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M33.5,42.1c-5.6,1.5-9.8,4.5-12.8,9.5c-4-4.2-3.9-6.4,0.6-9.1c1.6-1,3.4-1.9,5.2-2.2c2.2-0.4,4.4-0.6,6.6-0.8l0,0.5C33.1,40.7,33.2,41.5,33.5,42.1z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M33.5,37.9c-3.7-1.5-7.1-1.4-16,0c-1-4.9,0.3-6.5,5-6.6c4.7,0,8.8,1.6,12.4,4.1C34.2,36.2,33.8,37,33.5,37.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M35.8,34.6c-3-4.7-7.3-7.8-13.2-9c3.4-5.2,5.2-5.5,9.5-1.9c3.2,2.6,5.2,5.9,6.5,9.6C37.5,33.5,36.6,34,35.8,34.6z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M48,34.8c-0.5,0.7-1.4,1.1-2.1,1.6c-0.5-0.8-1.1-1.5-1.8-2c3.5-4.4,5.2-9.2,4.6-14.9c5.7,0.8,7.1,2.7,5.1,7.1C52.3,29.6,50,32.2,48,34.8z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M46.9,40c0-0.8-0.1-1.5-0.4-2.2c5.8-1.6,10-4.7,13.1-9.6c4.4,6.1,3.2,6.4-1.3,9.5c-1.5,1-3.3,1.7-5,2c-2.1,0.4-4.2,0.6-6.4,0.8L46.9,40z"
+              fillRule="evenodd"
+            />
+          </g>
+          <circle
+            className="ui-spinner_lighter"
+            clipRule="evenodd"
+            cx="40"
+            cy="40"
+            fillRule="evenodd"
+            r="36"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeMiterlimit="10"
+            strokeWidth="8"
+          />
+        </g>
+      </svg>
+    </div>
+    <span
+      className="ui-spinner__loading-text"
+    >
+       
+       
+    </span>
+  </div>
+  <div
+    className="ui-spinner__content"
+  >
+    Extra small
+  </div>
+</div>
+`;
+
+exports[`Spinner #render() should properly handle loading mode 1`] = `
+<div
+  className="ui-spinner__wrapper ui-spinner__wrapper_loading"
+>
+  <div
+    className="ui-spinner__loading-section"
+  >
+    <div
+      className="ui-spinner ui-spinner_size_m"
+    >
+      <svg
+        version="1.1"
+        viewBox="0 0 80 80"
+        x="0px"
+        xlinkHref="http://www.w3.org/1999/xlink"
+        xmlSpace="preserve"
+        xmlns="http://www.w3.org/2000/svg"
+        y="0px"
+      >
+        <g>
+          <g>
+            <circle
+              clipRule="evenodd"
+              cx="40"
+              cy="40"
+              fillRule="evenodd"
+              r="34.3"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M39.9,33.1c0.5-5.4-1.5-10.4-5.2-14.9c6.1-2.1,7.6-1.5,8.6,3.8c0.5,2.9,0.4,6,0.1,9c-0.1,0.9-0.3,1.8-0.7,2.7c-0.8-0.3-1.8-0.6-2.7-0.6H39.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M46.6,41.9c5.3,2,10.6,2.1,16-0.3c0.8,5.6-0.3,7-5.4,6.9c-4.6,0-8.5-1.6-12-4.1C45.9,43.7,46.3,42.8,46.6,41.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M44.3,45.4c3.1,4.5,7.2,7.7,13.2,8.9c-3.2,5.1-5.1,5.5-9.2,2.1c-3.2-2.6-5.3-5.9-6.5-9.8C42.7,46.4,43.5,46,44.3,45.4z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M40.1,46.9c-0.1,5.6,1.3,10.4,5.3,14.5c-5.6,2.6-7.2,2-8.6-3.3c-0.5-1.8-0.8-3.7-0.6-5.6c0.2-2,0.6-4.1,1.1-6.2c0.8,0.3,1.7,0.5,2.7,0.5H40.1z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M36,45.5c-3.5,4.3-5,9.2-4.7,14.8c-5.7-1.2-6.8-2.7-4.9-7.3c1.1-2.5,2.6-4.8,4.4-6.8c0.9-1,2-1.9,3.3-2.8C34.6,44.3,35.2,45,36,45.5z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M33.5,42.1c-5.6,1.5-9.8,4.5-12.8,9.5c-4-4.2-3.9-6.4,0.6-9.1c1.6-1,3.4-1.9,5.2-2.2c2.2-0.4,4.4-0.6,6.6-0.8l0,0.5C33.1,40.7,33.2,41.5,33.5,42.1z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M33.5,37.9c-3.7-1.5-7.1-1.4-16,0c-1-4.9,0.3-6.5,5-6.6c4.7,0,8.8,1.6,12.4,4.1C34.2,36.2,33.8,37,33.5,37.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M35.8,34.6c-3-4.7-7.3-7.8-13.2-9c3.4-5.2,5.2-5.5,9.5-1.9c3.2,2.6,5.2,5.9,6.5,9.6C37.5,33.5,36.6,34,35.8,34.6z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M48,34.8c-0.5,0.7-1.4,1.1-2.1,1.6c-0.5-0.8-1.1-1.5-1.8-2c3.5-4.4,5.2-9.2,4.6-14.9c5.7,0.8,7.1,2.7,5.1,7.1C52.3,29.6,50,32.2,48,34.8z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M46.9,40c0-0.8-0.1-1.5-0.4-2.2c5.8-1.6,10-4.7,13.1-9.6c4.4,6.1,3.2,6.4-1.3,9.5c-1.5,1-3.3,1.7-5,2c-2.1,0.4-4.2,0.6-6.4,0.8L46.9,40z"
+              fillRule="evenodd"
+            />
+          </g>
+          <circle
+            className="ui-spinner_lighter"
+            clipRule="evenodd"
+            cx="40"
+            cy="40"
+            fillRule="evenodd"
+            r="36"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeMiterlimit="10"
+            strokeWidth="8"
+          />
+        </g>
+      </svg>
+    </div>
+    <span
+      className="ui-spinner__loading-text"
+    >
+       
+       
+    </span>
+  </div>
+  <div
+    className="ui-spinner__content"
+  >
+    Some content
+  </div>
 </div>
 `;
 
 exports[`Spinner #render() should return base class with mods for strings as class and string as mods 1`] = `
 <div
-  className="ui-spinner ui-spinner_size_xs"
+  className="ui-spinner__wrapper ui-spinner__wrapper_loading"
 >
-  <svg
-    version="1.1"
-    viewBox="0 0 80 80"
-    x="0px"
-    xlinkHref="http://www.w3.org/1999/xlink"
-    xmlSpace="preserve"
-    xmlns="http://www.w3.org/2000/svg"
-    y="0px"
+  <div
+    className="ui-spinner__loading-section"
   >
-    <g>
-      <g>
-        <circle
-          clipRule="evenodd"
-          cx="40"
-          cy="40"
-          fillRule="evenodd"
-          r="34.3"
-        />
-        <path
-          className="ui-spinner_darker"
-          clipRule="evenodd"
-          d="M39.9,33.1c0.5-5.4-1.5-10.4-5.2-14.9c6.1-2.1,7.6-1.5,8.6,3.8c0.5,2.9,0.4,6,0.1,9c-0.1,0.9-0.3,1.8-0.7,2.7c-0.8-0.3-1.8-0.6-2.7-0.6H39.9z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_dark"
-          clipRule="evenodd"
-          d="M46.6,41.9c5.3,2,10.6,2.1,16-0.3c0.8,5.6-0.3,7-5.4,6.9c-4.6,0-8.5-1.6-12-4.1C45.9,43.7,46.3,42.8,46.6,41.9z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_dark"
-          clipRule="evenodd"
-          d="M44.3,45.4c3.1,4.5,7.2,7.7,13.2,8.9c-3.2,5.1-5.1,5.5-9.2,2.1c-3.2-2.6-5.3-5.9-6.5-9.8C42.7,46.4,43.5,46,44.3,45.4z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_dark"
-          clipRule="evenodd"
-          d="M40.1,46.9c-0.1,5.6,1.3,10.4,5.3,14.5c-5.6,2.6-7.2,2-8.6-3.3c-0.5-1.8-0.8-3.7-0.6-5.6c0.2-2,0.6-4.1,1.1-6.2c0.8,0.3,1.7,0.5,2.7,0.5H40.1z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_dark"
-          clipRule="evenodd"
-          d="M36,45.5c-3.5,4.3-5,9.2-4.7,14.8c-5.7-1.2-6.8-2.7-4.9-7.3c1.1-2.5,2.6-4.8,4.4-6.8c0.9-1,2-1.9,3.3-2.8C34.6,44.3,35.2,45,36,45.5z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_dark"
-          clipRule="evenodd"
-          d="M33.5,42.1c-5.6,1.5-9.8,4.5-12.8,9.5c-4-4.2-3.9-6.4,0.6-9.1c1.6-1,3.4-1.9,5.2-2.2c2.2-0.4,4.4-0.6,6.6-0.8l0,0.5C33.1,40.7,33.2,41.5,33.5,42.1z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_darker"
-          clipRule="evenodd"
-          d="M33.5,37.9c-3.7-1.5-7.1-1.4-16,0c-1-4.9,0.3-6.5,5-6.6c4.7,0,8.8,1.6,12.4,4.1C34.2,36.2,33.8,37,33.5,37.9z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_darker"
-          clipRule="evenodd"
-          d="M35.8,34.6c-3-4.7-7.3-7.8-13.2-9c3.4-5.2,5.2-5.5,9.5-1.9c3.2,2.6,5.2,5.9,6.5,9.6C37.5,33.5,36.6,34,35.8,34.6z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_dark"
-          clipRule="evenodd"
-          d="M48,34.8c-0.5,0.7-1.4,1.1-2.1,1.6c-0.5-0.8-1.1-1.5-1.8-2c3.5-4.4,5.2-9.2,4.6-14.9c5.7,0.8,7.1,2.7,5.1,7.1C52.3,29.6,50,32.2,48,34.8z"
-          fillRule="evenodd"
-        />
-        <path
-          className="ui-spinner_dark"
-          clipRule="evenodd"
-          d="M46.9,40c0-0.8-0.1-1.5-0.4-2.2c5.8-1.6,10-4.7,13.1-9.6c4.4,6.1,3.2,6.4-1.3,9.5c-1.5,1-3.3,1.7-5,2c-2.1,0.4-4.2,0.6-6.4,0.8L46.9,40z"
-          fillRule="evenodd"
-        />
-      </g>
-      <circle
-        className="ui-spinner_lighter"
-        clipRule="evenodd"
-        cx="40"
-        cy="40"
-        fillRule="evenodd"
-        r="36"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeMiterlimit="10"
-        strokeWidth="8"
-      />
-    </g>
-  </svg>
+    <div
+      className="ui-spinner ui-spinner_size_xs"
+    >
+      <svg
+        version="1.1"
+        viewBox="0 0 80 80"
+        x="0px"
+        xlinkHref="http://www.w3.org/1999/xlink"
+        xmlSpace="preserve"
+        xmlns="http://www.w3.org/2000/svg"
+        y="0px"
+      >
+        <g>
+          <g>
+            <circle
+              clipRule="evenodd"
+              cx="40"
+              cy="40"
+              fillRule="evenodd"
+              r="34.3"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M39.9,33.1c0.5-5.4-1.5-10.4-5.2-14.9c6.1-2.1,7.6-1.5,8.6,3.8c0.5,2.9,0.4,6,0.1,9c-0.1,0.9-0.3,1.8-0.7,2.7c-0.8-0.3-1.8-0.6-2.7-0.6H39.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M46.6,41.9c5.3,2,10.6,2.1,16-0.3c0.8,5.6-0.3,7-5.4,6.9c-4.6,0-8.5-1.6-12-4.1C45.9,43.7,46.3,42.8,46.6,41.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M44.3,45.4c3.1,4.5,7.2,7.7,13.2,8.9c-3.2,5.1-5.1,5.5-9.2,2.1c-3.2-2.6-5.3-5.9-6.5-9.8C42.7,46.4,43.5,46,44.3,45.4z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M40.1,46.9c-0.1,5.6,1.3,10.4,5.3,14.5c-5.6,2.6-7.2,2-8.6-3.3c-0.5-1.8-0.8-3.7-0.6-5.6c0.2-2,0.6-4.1,1.1-6.2c0.8,0.3,1.7,0.5,2.7,0.5H40.1z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M36,45.5c-3.5,4.3-5,9.2-4.7,14.8c-5.7-1.2-6.8-2.7-4.9-7.3c1.1-2.5,2.6-4.8,4.4-6.8c0.9-1,2-1.9,3.3-2.8C34.6,44.3,35.2,45,36,45.5z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M33.5,42.1c-5.6,1.5-9.8,4.5-12.8,9.5c-4-4.2-3.9-6.4,0.6-9.1c1.6-1,3.4-1.9,5.2-2.2c2.2-0.4,4.4-0.6,6.6-0.8l0,0.5C33.1,40.7,33.2,41.5,33.5,42.1z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M33.5,37.9c-3.7-1.5-7.1-1.4-16,0c-1-4.9,0.3-6.5,5-6.6c4.7,0,8.8,1.6,12.4,4.1C34.2,36.2,33.8,37,33.5,37.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M35.8,34.6c-3-4.7-7.3-7.8-13.2-9c3.4-5.2,5.2-5.5,9.5-1.9c3.2,2.6,5.2,5.9,6.5,9.6C37.5,33.5,36.6,34,35.8,34.6z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M48,34.8c-0.5,0.7-1.4,1.1-2.1,1.6c-0.5-0.8-1.1-1.5-1.8-2c3.5-4.4,5.2-9.2,4.6-14.9c5.7,0.8,7.1,2.7,5.1,7.1C52.3,29.6,50,32.2,48,34.8z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M46.9,40c0-0.8-0.1-1.5-0.4-2.2c5.8-1.6,10-4.7,13.1-9.6c4.4,6.1,3.2,6.4-1.3,9.5c-1.5,1-3.3,1.7-5,2c-2.1,0.4-4.2,0.6-6.4,0.8L46.9,40z"
+              fillRule="evenodd"
+            />
+          </g>
+          <circle
+            className="ui-spinner_lighter"
+            clipRule="evenodd"
+            cx="40"
+            cy="40"
+            fillRule="evenodd"
+            r="36"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeMiterlimit="10"
+            strokeWidth="8"
+          />
+        </g>
+      </svg>
+    </div>
+    <span
+      className="ui-spinner__loading-text"
+    >
+       
+       
+    </span>
+  </div>
+  <div
+    className="ui-spinner__content"
+  >
+    Extra small
+  </div>
 </div>
 `;
 
 exports[`Spinner #render() should return base class with mods for strings as class and string as mods 2`] = `
+<div
+  className="ui-spinner__wrapper ui-spinner__wrapper_loading"
+>
+  <div
+    className="ui-spinner__loading-section"
+  >
+    <div
+      className="ui-spinner ui-spinner_size_m"
+    >
+      <svg
+        version="1.1"
+        viewBox="0 0 80 80"
+        x="0px"
+        xlinkHref="http://www.w3.org/1999/xlink"
+        xmlSpace="preserve"
+        xmlns="http://www.w3.org/2000/svg"
+        y="0px"
+      >
+        <g>
+          <g>
+            <circle
+              clipRule="evenodd"
+              cx="40"
+              cy="40"
+              fillRule="evenodd"
+              r="34.3"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M39.9,33.1c0.5-5.4-1.5-10.4-5.2-14.9c6.1-2.1,7.6-1.5,8.6,3.8c0.5,2.9,0.4,6,0.1,9c-0.1,0.9-0.3,1.8-0.7,2.7c-0.8-0.3-1.8-0.6-2.7-0.6H39.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M46.6,41.9c5.3,2,10.6,2.1,16-0.3c0.8,5.6-0.3,7-5.4,6.9c-4.6,0-8.5-1.6-12-4.1C45.9,43.7,46.3,42.8,46.6,41.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M44.3,45.4c3.1,4.5,7.2,7.7,13.2,8.9c-3.2,5.1-5.1,5.5-9.2,2.1c-3.2-2.6-5.3-5.9-6.5-9.8C42.7,46.4,43.5,46,44.3,45.4z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M40.1,46.9c-0.1,5.6,1.3,10.4,5.3,14.5c-5.6,2.6-7.2,2-8.6-3.3c-0.5-1.8-0.8-3.7-0.6-5.6c0.2-2,0.6-4.1,1.1-6.2c0.8,0.3,1.7,0.5,2.7,0.5H40.1z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M36,45.5c-3.5,4.3-5,9.2-4.7,14.8c-5.7-1.2-6.8-2.7-4.9-7.3c1.1-2.5,2.6-4.8,4.4-6.8c0.9-1,2-1.9,3.3-2.8C34.6,44.3,35.2,45,36,45.5z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M33.5,42.1c-5.6,1.5-9.8,4.5-12.8,9.5c-4-4.2-3.9-6.4,0.6-9.1c1.6-1,3.4-1.9,5.2-2.2c2.2-0.4,4.4-0.6,6.6-0.8l0,0.5C33.1,40.7,33.2,41.5,33.5,42.1z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M33.5,37.9c-3.7-1.5-7.1-1.4-16,0c-1-4.9,0.3-6.5,5-6.6c4.7,0,8.8,1.6,12.4,4.1C34.2,36.2,33.8,37,33.5,37.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M35.8,34.6c-3-4.7-7.3-7.8-13.2-9c3.4-5.2,5.2-5.5,9.5-1.9c3.2,2.6,5.2,5.9,6.5,9.6C37.5,33.5,36.6,34,35.8,34.6z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M48,34.8c-0.5,0.7-1.4,1.1-2.1,1.6c-0.5-0.8-1.1-1.5-1.8-2c3.5-4.4,5.2-9.2,4.6-14.9c5.7,0.8,7.1,2.7,5.1,7.1C52.3,29.6,50,32.2,48,34.8z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M46.9,40c0-0.8-0.1-1.5-0.4-2.2c5.8-1.6,10-4.7,13.1-9.6c4.4,6.1,3.2,6.4-1.3,9.5c-1.5,1-3.3,1.7-5,2c-2.1,0.4-4.2,0.6-6.4,0.8L46.9,40z"
+              fillRule="evenodd"
+            />
+          </g>
+          <circle
+            className="ui-spinner_lighter"
+            clipRule="evenodd"
+            cx="40"
+            cy="40"
+            fillRule="evenodd"
+            r="36"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeMiterlimit="10"
+            strokeWidth="8"
+          />
+        </g>
+      </svg>
+    </div>
+    <span
+      className="ui-spinner__loading-text"
+    >
+       
+       
+    </span>
+  </div>
+  <div
+    className="ui-spinner__content"
+  >
+    Medium/Default
+  </div>
+</div>
+`;
+
+exports[`Spinner #render() should return just normal spinner without children & use default props 1`] = `
 <div
   className="ui-spinner ui-spinner_size_m"
 >
@@ -297,5 +585,124 @@ exports[`Spinner #render() should return base class with mods for strings as cla
       />
     </g>
   </svg>
+</div>
+`;
+
+exports[`Spinner #render() should return wrapper if using with children & add handle transparency 1`] = `
+<div
+  className="ui-spinner__wrapper ui-spinner__wrapper_loading ui-spinner__wrapper_transparent"
+>
+  <div
+    className="ui-spinner__loading-section"
+  >
+    <div
+      className="ui-spinner ui-spinner_size_m"
+    >
+      <svg
+        version="1.1"
+        viewBox="0 0 80 80"
+        x="0px"
+        xlinkHref="http://www.w3.org/1999/xlink"
+        xmlSpace="preserve"
+        xmlns="http://www.w3.org/2000/svg"
+        y="0px"
+      >
+        <g>
+          <g>
+            <circle
+              clipRule="evenodd"
+              cx="40"
+              cy="40"
+              fillRule="evenodd"
+              r="34.3"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M39.9,33.1c0.5-5.4-1.5-10.4-5.2-14.9c6.1-2.1,7.6-1.5,8.6,3.8c0.5,2.9,0.4,6,0.1,9c-0.1,0.9-0.3,1.8-0.7,2.7c-0.8-0.3-1.8-0.6-2.7-0.6H39.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M46.6,41.9c5.3,2,10.6,2.1,16-0.3c0.8,5.6-0.3,7-5.4,6.9c-4.6,0-8.5-1.6-12-4.1C45.9,43.7,46.3,42.8,46.6,41.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M44.3,45.4c3.1,4.5,7.2,7.7,13.2,8.9c-3.2,5.1-5.1,5.5-9.2,2.1c-3.2-2.6-5.3-5.9-6.5-9.8C42.7,46.4,43.5,46,44.3,45.4z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M40.1,46.9c-0.1,5.6,1.3,10.4,5.3,14.5c-5.6,2.6-7.2,2-8.6-3.3c-0.5-1.8-0.8-3.7-0.6-5.6c0.2-2,0.6-4.1,1.1-6.2c0.8,0.3,1.7,0.5,2.7,0.5H40.1z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M36,45.5c-3.5,4.3-5,9.2-4.7,14.8c-5.7-1.2-6.8-2.7-4.9-7.3c1.1-2.5,2.6-4.8,4.4-6.8c0.9-1,2-1.9,3.3-2.8C34.6,44.3,35.2,45,36,45.5z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M33.5,42.1c-5.6,1.5-9.8,4.5-12.8,9.5c-4-4.2-3.9-6.4,0.6-9.1c1.6-1,3.4-1.9,5.2-2.2c2.2-0.4,4.4-0.6,6.6-0.8l0,0.5C33.1,40.7,33.2,41.5,33.5,42.1z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M33.5,37.9c-3.7-1.5-7.1-1.4-16,0c-1-4.9,0.3-6.5,5-6.6c4.7,0,8.8,1.6,12.4,4.1C34.2,36.2,33.8,37,33.5,37.9z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_darker"
+              clipRule="evenodd"
+              d="M35.8,34.6c-3-4.7-7.3-7.8-13.2-9c3.4-5.2,5.2-5.5,9.5-1.9c3.2,2.6,5.2,5.9,6.5,9.6C37.5,33.5,36.6,34,35.8,34.6z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M48,34.8c-0.5,0.7-1.4,1.1-2.1,1.6c-0.5-0.8-1.1-1.5-1.8-2c3.5-4.4,5.2-9.2,4.6-14.9c5.7,0.8,7.1,2.7,5.1,7.1C52.3,29.6,50,32.2,48,34.8z"
+              fillRule="evenodd"
+            />
+            <path
+              className="ui-spinner_dark"
+              clipRule="evenodd"
+              d="M46.9,40c0-0.8-0.1-1.5-0.4-2.2c5.8-1.6,10-4.7,13.1-9.6c4.4,6.1,3.2,6.4-1.3,9.5c-1.5,1-3.3,1.7-5,2c-2.1,0.4-4.2,0.6-6.4,0.8L46.9,40z"
+              fillRule="evenodd"
+            />
+          </g>
+          <circle
+            className="ui-spinner_lighter"
+            clipRule="evenodd"
+            cx="40"
+            cy="40"
+            fillRule="evenodd"
+            r="36"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeMiterlimit="10"
+            strokeWidth="8"
+          />
+        </g>
+      </svg>
+    </div>
+    <span
+      className="ui-spinner__loading-text"
+    >
+       
+       
+    </span>
+  </div>
+  <div
+    className="ui-spinner__content"
+  >
+    Some content
+  </div>
 </div>
 `;

--- a/tests/unit/spinner/spinner.spec.js
+++ b/tests/unit/spinner/spinner.spec.js
@@ -31,6 +31,16 @@ describe('Spinner', () => {
       expect(wrapper).toMatchSnapshot();
     });
 
+    it('should handle custom className passed to the wrapper', () => {
+      const wrapper = shallow(
+        <Spinner wrapperClassName="my-custom-class">
+          Testing custom class...
+        </Spinner>
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
     it('should return just normal spinner without children & use default props', () => {
       const wrapper = shallow(
         <Spinner />

--- a/tests/unit/spinner/spinner.spec.js
+++ b/tests/unit/spinner/spinner.spec.js
@@ -30,5 +30,43 @@ describe('Spinner', () => {
 
       expect(wrapper).toMatchSnapshot();
     });
+
+    it('should return just normal spinner without children & use default props', () => {
+      const wrapper = shallow(
+        <Spinner />
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should return wrapper if using with children & add handle transparency', () => {
+      const wrapper = shallow(
+        <Spinner transparent>
+          Some content
+        </Spinner>
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should properly handle loading mode', () => {
+      const wrapper = shallow(
+        <Spinner loading>
+          Some content
+        </Spinner>
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should handle non-loading mode', () => {
+      const wrapper = shallow(
+        <Spinner loading={false}>
+          Some content
+        </Spinner>
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 });

--- a/themes/_default.yaml
+++ b/themes/_default.yaml
@@ -542,6 +542,15 @@ spinner:
     lighter: "var(--tx-generic-color-accent)"
     dark: "var(--tx-generic-color-active)"
     darker: "var(--tx-generic-color-primary-lighter)"
+  text:
+    font-size: "19px"
+  wrapper:
+    border-radius: "8px"
+    z-index: "100"
+    transparent:
+      opacity: "0.5"
+  content:
+    z-index: "99"
 carousel:
   track:
     transition: "transform 0.5s cubic-bezier(0.2, 1, 0.3, 1)"

--- a/themes/_default.yaml
+++ b/themes/_default.yaml
@@ -542,15 +542,6 @@ spinner:
     lighter: "var(--tx-generic-color-accent)"
     dark: "var(--tx-generic-color-active)"
     darker: "var(--tx-generic-color-primary-lighter)"
-  text:
-    font-size: "19px"
-  wrapper:
-    border-radius: "8px"
-    z-index: "100"
-    transparent:
-      opacity: "0.5"
-  content:
-    z-index: "99"
 carousel:
   track:
     transition: "transform 0.5s cubic-bezier(0.2, 1, 0.3, 1)"


### PR DESCRIPTION
# What does this PR do:

    This PR extends Spinner component to be able to wrap children into the loading section.

# Where should the reviewer start:

 components/spinner/spinner.js
