### PR TITLE
Fix spinner path in loading overlay

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -3,8 +3,8 @@ import AutoCompleteItem from './autoComplete/autoCompleteItem';
 import Badge from './badge/badge';
 import Button from './button/button';
 import Calendar from './calendar/calendar';
-import Carousel from './carousel/carousel';
 import Card from './card/card';
+import Carousel from './carousel/carousel';
 import Checkbox from './checkbox/checkbox';
 import Collapse from './collapse/collapse';
 import CollapseItem from './collapse/collapseItem';
@@ -14,6 +14,7 @@ import Global from './global/global';
 import GoogleMap from './googleMap/googleMap';
 import Input from './input/input';
 import List from './list/list';
+import LoadingOverlay from './loadingOverlay/loadingOverlay';
 import MessageBox from './messageBox/messageBox';
 import Modal from './modal/modal';
 import OverlayTrigger from './overlayTrigger/overlayTrigger';
@@ -33,8 +34,8 @@ export default {
   Badge,
   Button,
   Calendar,
-  Carousel,
   Card,
+  Carousel,
   Checkbox,
   Collapse,
   CollapseItem,
@@ -44,6 +45,7 @@ export default {
   GoogleMap,
   Input,
   List,
+  LoadingOverlay,
   MessageBox,
   Modal,
   OverlayTrigger,

--- a/components/index.scss
+++ b/components/index.scss
@@ -3,8 +3,8 @@
 @import "./badge/badge.scss";
 @import "./button/button.scss";
 @import "./calendar/calendar.scss";
-@import "./carousel/carousel.css";
 @import "./card/card.css";
+@import "./carousel/carousel.css";
 @import "./checkbox/checkbox.scss";
 @import "./collapse/collapse.scss";
 @import "./collapse/collapseItem.scss";
@@ -14,6 +14,7 @@
 @import "./googleMap/googleMap.css";
 @import "./input/input.scss";
 @import "./list/list.scss";
+@import "./loadingOverlay/loadingOverlay.css";
 @import "./messageBox/messageBox.scss";
 @import "./modal/modal.scss";
 @import "./overlayTrigger/overlayTrigger.scss";

--- a/components/loadingOverlay/loadingOverlay.css
+++ b/components/loadingOverlay/loadingOverlay.css
@@ -1,3 +1,5 @@
+@value messageMargin: 8px;
+
 .ui-loading-overlay {
   border-radius: 8px;
   overflow: hidden;
@@ -34,19 +36,19 @@
 }
 
 .ui-loading-overlay__loading-message_left {
-  margin-right: 8px;
+  margin-right: messageMargin;
 }
 
 .ui-loading-overlay__loading-message_right {
-  margin-left: 8px;
+  margin-left: messageMargin;
 }
 
 .ui-loading-overlay__loading-message_top {
-  margin-bottom: 8px;
+  margin-bottom: messageMargin;
 }
 
 .ui-loading-overlay__loading-message_bottom {
-  margin-top: 8px;
+  margin-top: messageMargin;
 }
 
 .ui-loading-overlay__content {

--- a/components/loadingOverlay/loadingOverlay.css
+++ b/components/loadingOverlay/loadingOverlay.css
@@ -1,0 +1,70 @@
+.ui-loading-overlay {
+  border-radius: 8px;
+  overflow: hidden;
+  position: relative;
+}
+
+.ui-loading-overlay__loading-container {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  position: absolute;
+  width: 100%;
+  z-index: 100;
+}
+
+.ui-loading-overlay__loading-container_message-left {
+  flex-direction: row-reverse;
+}
+
+.ui-loading-overlay__loading-container_message-top {
+  flex-direction: column-reverse;
+}
+
+.ui-loading-overlay__loading-container_message-bottom {
+  flex-direction: column;
+}
+
+.ui-loading-overlay__loading-message {
+  color: var(--tx-generic-color-primary);
+  font-family: var(--tx-generic-font-primary-font-family), var(--tx-generic-font-primary-generic-family);
+  font-size: 19px;
+  font-weight: var(--tx-generic-font-primary-weight-semibold);
+}
+
+.ui-loading-overlay__loading-message_left {
+  margin-right: 8px;
+}
+
+.ui-loading-overlay__loading-message_right {
+  margin-left: 8px;
+}
+
+.ui-loading-overlay__loading-message_top {
+  margin-bottom: 8px;
+}
+
+.ui-loading-overlay__loading-message_bottom {
+  margin-top: 8px;
+}
+
+.ui-loading-overlay__content {
+  transition: all 0.2s ease-in-out;
+}
+
+.ui-loading-overlay_loading .ui-loading-overlay__content:before {
+  background: var(--tx-generic-color-secondary-light);
+  bottom: 0;
+  content: "";
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transition: all 0.3s;
+  z-index: 99;
+}
+
+.ui-loading-overlay_transparent .ui-loading-overlay__content:before {
+  opacity: 0.5;
+}

--- a/components/loadingOverlay/loadingOverlay.js
+++ b/components/loadingOverlay/loadingOverlay.js
@@ -1,0 +1,97 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import classnames from 'classnames';
+import { getClassNamesWithMods } from '../_helpers';
+import Spinner from '../';
+
+const LoadingOverlay = ({
+  children,
+  className,
+  loading,
+  message,
+  messageDirection,
+  spinner,
+  transparency,
+}) => {
+  if (!children) {
+    return null;
+  }
+
+  let loadingSection = null;
+
+  const spinnerComponent = (
+    <Spinner/>
+  );
+
+  if (loading) {
+    loadingSection = (
+      <div className="ui-loading-overlay__loading-container">
+        {spinner && spinnerComponent}
+        <span
+          classNames={
+            getClassNamesWithMods('ui-loading-overlay__loading-message', { [messageDirection]: messageDirection })
+          }
+        >
+          {message}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={
+        classnames(
+          getClassNamesWithMods('ui-loading-overlay', { loading, transparent: transparency }),
+          className
+        )
+      }
+    >
+      {loadingSection}
+      <div className="ui-loading-overlay__content">
+        {children}
+      </div>
+    </div>
+  );
+};
+
+LoadingOverlay.defaultProps = {
+  loading: false,
+  message: '',
+  messageDirection: 'right',
+  spinner: true,
+  transparency: false,
+};
+
+LoadingOverlay.propTypes = {
+  /**
+   * Child component(s) which will be wrapped into the loading section.
+   */
+  children: PropTypes.node,
+  /**
+   * Custom className that can be passed to the root wrapper container.
+   */
+  className: PropTypes.string,
+  /**
+   * If loading is enabled, it'll show the spinner / loading message. If not, then content.
+   */
+  loading: PropTypes.bool,
+  /**
+   * Simple text to be shown next to the spinner or instead.
+   */
+  message: PropTypes.node,
+  /**
+   * Message position relatively to the spinner if any.
+   */
+  messageDirection: PropTypes.oneOf(['right', 'left', 'top', 'bottom']),
+  /**
+   * Determines whether to show spinner component while loading or not.
+   */
+  spinner: PropTypes.bool,
+  /**
+   * Enable transparency for the loading section. You will partially see the content while loading.
+   */
+  transparency: PropTypes.bool,
+};
+
+export default LoadingOverlay;

--- a/components/loadingOverlay/loadingOverlay.js
+++ b/components/loadingOverlay/loadingOverlay.js
@@ -35,13 +35,15 @@ const LoadingOverlay = ({
         }
       >
         {spinner && spinnerComponent}
-        <span
-          className={
-            getClassNamesWithMods('ui-loading-overlay__loading-message', [spinner && !!message && messageDirection])
-          }
-        >
-          {message}
-        </span>
+        {message && (
+          <span
+            className={
+              getClassNamesWithMods('ui-loading-overlay__loading-message', [spinner && !!message && messageDirection])
+            }
+          >
+            {message}
+          </span>
+        )}
       </div>
     );
   }

--- a/components/loadingOverlay/loadingOverlay.js
+++ b/components/loadingOverlay/loadingOverlay.js
@@ -30,14 +30,14 @@ const LoadingOverlay = ({
         className={
           getClassNamesWithMods(
             'ui-loading-overlay__loading-container',
-            [spinner && message && `message-${messageDirection}`]
+            [spinner && !!message && `message-${messageDirection}`]
           )
         }
       >
         {spinner && spinnerComponent}
         <span
           className={
-            getClassNamesWithMods('ui-loading-overlay__loading-message', [spinner && message && messageDirection])
+            getClassNamesWithMods('ui-loading-overlay__loading-message', [spinner && !!message && messageDirection])
           }
         >
           {message}

--- a/components/loadingOverlay/loadingOverlay.js
+++ b/components/loadingOverlay/loadingOverlay.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { getClassNamesWithMods } from '../_helpers';
-import Spinner from '../';
+import { Spinner } from '../';
 
 const LoadingOverlay = ({
   children,
@@ -20,16 +20,24 @@ const LoadingOverlay = ({
   let loadingSection = null;
 
   const spinnerComponent = (
-    <Spinner/>
+    <Spinner size="s"/>
   );
 
   if (loading) {
     loadingSection = (
-      <div className="ui-loading-overlay__loading-container">
+      <div
+        className="ui-loading-overlay__loading-container"
+        className={
+          getClassNamesWithMods(
+            'ui-loading-overlay__loading-container',
+            [spinner && message && `message-${messageDirection}`]
+          )
+        }
+      >
         {spinner && spinnerComponent}
         <span
-          classNames={
-            getClassNamesWithMods('ui-loading-overlay__loading-message', { [messageDirection]: messageDirection })
+          className={
+            getClassNamesWithMods('ui-loading-overlay__loading-message', [spinner && message && messageDirection])
           }
         >
           {message}
@@ -67,13 +75,13 @@ LoadingOverlay.propTypes = {
   /**
    * Child component(s) which will be wrapped into the loading section.
    */
-  children: PropTypes.node,
+  children: PropTypes.node.isRequired,
   /**
    * Custom className that can be passed to the root wrapper container.
    */
   className: PropTypes.string,
   /**
-   * If loading is enabled, it'll show the spinner / loading message. If not, then content.
+   * If loading is enabled, it'll show the overlay and, optionally, spinner / message. If not, then content.
    */
   loading: PropTypes.bool,
   /**

--- a/components/loadingOverlay/loadingOverlay.js
+++ b/components/loadingOverlay/loadingOverlay.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { getClassNamesWithMods } from '../_helpers';
-import { Spinner } from '../';
+import Spinner from '../spinner/spinner';
 
 const LoadingOverlay = ({
   children,

--- a/components/loadingOverlay/loadingOverlay.md
+++ b/components/loadingOverlay/loadingOverlay.md
@@ -36,7 +36,7 @@ Loading overlay:
         <Checkbox
           checked={state.loading && state.spinner}
           disabled={!state.loading}
-          name="spinner"
+          name="showSpinner"
           onChange={() => setState({ spinner: !state.spinner })}
         >
           Show spinner

--- a/components/loadingOverlay/loadingOverlay.md
+++ b/components/loadingOverlay/loadingOverlay.md
@@ -1,0 +1,69 @@
+Loading overlay:
+
+    initialState = {
+      messageDirection: 'right',
+      loading: true,
+      transparency: false,
+      showLoadingMessage: true,
+      spinner: true,
+    };
+
+    <div>
+      <div>
+        <Checkbox
+          checked={state.loading}
+          name="loading"
+          onChange={() => setState({ loading: !state.loading })}
+        >
+          Enable loading
+        </Checkbox>
+        <Checkbox
+          checked={state.loading && state.transparency}
+          disabled={!state.loading}
+          name="transparency"
+          onChange={() => setState({ transparency: !state.transparency })}
+        >
+          Enable transparency
+        </Checkbox>
+        <Checkbox
+          checked={state.loading && state.showLoadingMessage}
+          disabled={!state.loading}
+          name="showLoadingMessage"
+          onChange={() => setState({ showLoadingMessage: !state.showLoadingMessage })}
+        >
+          Show loading message
+        </Checkbox>
+        <Checkbox
+          checked={state.loading && state.spinner}
+          disabled={!state.loading}
+          name="spinner"
+          onChange={() => setState({ spinner: !state.spinner })}
+        >
+          Show spinner
+        </Checkbox>
+        <div style={{ margin: '15px 0' }}>
+          <div style={{ marginBottom: '7px' }}> Message direction: </div>
+          {['left', 'right', 'top', 'bottom'].map(messageDirection => (
+            <RadioButton
+              checked={state.loading && state.spinner && state.showLoadingMessage && messageDirection === state.messageDirection}
+              children={messageDirection}
+              disabled={!(state.loading && state.spinner && state.showLoadingMessage)}
+              id={messageDirection}
+              key={messageDirection}
+              name="message-messageDirection"
+              onChange={onChange = e => setState({ messageDirection })}
+            />
+          ))}
+        </div>
+      </div>
+      <LoadingOverlay
+        loading={state.loading}
+        message={state.showLoadingMessage && "Loading"}
+        messageDirection={state.messageDirection}
+        spinner={state.spinner}
+        transparency={state.transparency}
+      >
+        At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat.
+        <button onClick={() => console.log('clicked!')}> click! </button>
+      </LoadingOverlay>
+    </div>

--- a/components/spinner/spinner.js
+++ b/components/spinner/spinner.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { getClassNamesWithMods } from '../_helpers';
 
 /**
- * General Spinner component. Use when you need spinner
+ * General Spinner component.
  */
 function Spinner(props) {
   const { size } = props;

--- a/tests/unit/loadingOverlay/__snapshots__/loadingOverlay.spec.js.snap
+++ b/tests/unit/loadingOverlay/__snapshots__/loadingOverlay.spec.js.snap
@@ -17,11 +17,13 @@ exports[`LoadingOverlay #render() render loading overlay in loading mode 1`] = `
   className="ui-loading-overlay ui-loading-overlay_loading my-custom-class"
 >
   <div
-    className="ui-loading-overlay__loading-container"
+    className="ui-loading-overlay__loading-container ui-loading-overlay__loading-container_message-right"
   >
-    <[object Object] />
+    <Spinner
+      size="s"
+    />
     <span
-      classNames="ui-loading-overlay__loading-message ui-loading-overlay__loading-message_right"
+      className="ui-loading-overlay__loading-message ui-loading-overlay__loading-message_right"
     />
   </div>
   <div
@@ -49,11 +51,13 @@ exports[`LoadingOverlay #render() render loading overlay with left message direc
   className="ui-loading-overlay ui-loading-overlay_loading my-custom-class"
 >
   <div
-    className="ui-loading-overlay__loading-container"
+    className="ui-loading-overlay__loading-container ui-loading-overlay__loading-container_message-left"
   >
-    <[object Object] />
+    <Spinner
+      size="s"
+    />
     <span
-      classNames="ui-loading-overlay__loading-message ui-loading-overlay__loading-message_left"
+      className="ui-loading-overlay__loading-message ui-loading-overlay__loading-message_left"
     />
   </div>
   <div
@@ -69,11 +73,13 @@ exports[`LoadingOverlay #render() render loading overlay with loading message 1`
   className="ui-loading-overlay ui-loading-overlay_loading my-custom-class"
 >
   <div
-    className="ui-loading-overlay__loading-container"
+    className="ui-loading-overlay__loading-container ui-loading-overlay__loading-container_message-right"
   >
-    <[object Object] />
+    <Spinner
+      size="s"
+    />
     <span
-      classNames="ui-loading-overlay__loading-message ui-loading-overlay__loading-message_right"
+      className="ui-loading-overlay__loading-message ui-loading-overlay__loading-message_right"
     >
       Loading your data...
     </span>
@@ -103,11 +109,13 @@ exports[`LoadingOverlay #render() render loading overlay with transparency in lo
   className="ui-loading-overlay ui-loading-overlay_loading ui-loading-overlay_transparent my-custom-class"
 >
   <div
-    className="ui-loading-overlay__loading-container"
+    className="ui-loading-overlay__loading-container ui-loading-overlay__loading-container_message-right"
   >
-    <[object Object] />
+    <Spinner
+      size="s"
+    />
     <span
-      classNames="ui-loading-overlay__loading-message ui-loading-overlay__loading-message_right"
+      className="ui-loading-overlay__loading-message ui-loading-overlay__loading-message_right"
     />
   </div>
   <div
@@ -128,7 +136,7 @@ exports[`LoadingOverlay #render() render without spinner 1`] = `
     className="ui-loading-overlay__loading-container"
   >
     <span
-      classNames="ui-loading-overlay__loading-message ui-loading-overlay__loading-message_right"
+      className="ui-loading-overlay__loading-message"
     />
   </div>
   <div

--- a/tests/unit/loadingOverlay/__snapshots__/loadingOverlay.spec.js.snap
+++ b/tests/unit/loadingOverlay/__snapshots__/loadingOverlay.spec.js.snap
@@ -1,0 +1,140 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LoadingOverlay #render() render basic loading overlay 1`] = `
+<div
+  className="ui-loading-overlay"
+>
+  <div
+    className="ui-loading-overlay__content"
+  >
+    Some data
+  </div>
+</div>
+`;
+
+exports[`LoadingOverlay #render() render loading overlay in loading mode 1`] = `
+<div
+  className="ui-loading-overlay ui-loading-overlay_loading my-custom-class"
+>
+  <div
+    className="ui-loading-overlay__loading-container"
+  >
+    <[object Object] />
+    <span
+      classNames="ui-loading-overlay__loading-message ui-loading-overlay__loading-message_right"
+    />
+  </div>
+  <div
+    className="ui-loading-overlay__content"
+  >
+    Data is loading...
+  </div>
+</div>
+`;
+
+exports[`LoadingOverlay #render() render loading overlay with custom class 1`] = `
+<div
+  className="ui-loading-overlay my-custom-class"
+>
+  <div
+    className="ui-loading-overlay__content"
+  >
+    Some data
+  </div>
+</div>
+`;
+
+exports[`LoadingOverlay #render() render loading overlay with left message direction 1`] = `
+<div
+  className="ui-loading-overlay ui-loading-overlay_loading my-custom-class"
+>
+  <div
+    className="ui-loading-overlay__loading-container"
+  >
+    <[object Object] />
+    <span
+      classNames="ui-loading-overlay__loading-message ui-loading-overlay__loading-message_left"
+    />
+  </div>
+  <div
+    className="ui-loading-overlay__content"
+  >
+    Data is loading...
+  </div>
+</div>
+`;
+
+exports[`LoadingOverlay #render() render loading overlay with loading message 1`] = `
+<div
+  className="ui-loading-overlay ui-loading-overlay_loading my-custom-class"
+>
+  <div
+    className="ui-loading-overlay__loading-container"
+  >
+    <[object Object] />
+    <span
+      classNames="ui-loading-overlay__loading-message ui-loading-overlay__loading-message_right"
+    >
+      Loading your data...
+    </span>
+  </div>
+  <div
+    className="ui-loading-overlay__content"
+  >
+    Data is loading...
+  </div>
+</div>
+`;
+
+exports[`LoadingOverlay #render() render loading overlay with transparency 1`] = `
+<div
+  className="ui-loading-overlay ui-loading-overlay_transparent my-custom-class"
+>
+  <div
+    className="ui-loading-overlay__content"
+  >
+    Some data
+  </div>
+</div>
+`;
+
+exports[`LoadingOverlay #render() render loading overlay with transparency in loading mode 1`] = `
+<div
+  className="ui-loading-overlay ui-loading-overlay_loading ui-loading-overlay_transparent my-custom-class"
+>
+  <div
+    className="ui-loading-overlay__loading-container"
+  >
+    <[object Object] />
+    <span
+      classNames="ui-loading-overlay__loading-message ui-loading-overlay__loading-message_right"
+    />
+  </div>
+  <div
+    className="ui-loading-overlay__content"
+  >
+    Data is loading... You can see that message.
+  </div>
+</div>
+`;
+
+exports[`LoadingOverlay #render() render without children - should return null 1`] = `""`;
+
+exports[`LoadingOverlay #render() render without spinner 1`] = `
+<div
+  className="ui-loading-overlay ui-loading-overlay_loading my-custom-class"
+>
+  <div
+    className="ui-loading-overlay__loading-container"
+  >
+    <span
+      classNames="ui-loading-overlay__loading-message ui-loading-overlay__loading-message_right"
+    />
+  </div>
+  <div
+    className="ui-loading-overlay__content"
+  >
+    Data is loading...
+  </div>
+</div>
+`;

--- a/tests/unit/loadingOverlay/__snapshots__/loadingOverlay.spec.js.snap
+++ b/tests/unit/loadingOverlay/__snapshots__/loadingOverlay.spec.js.snap
@@ -17,13 +17,13 @@ exports[`LoadingOverlay #render() render loading overlay in loading mode 1`] = `
   className="ui-loading-overlay ui-loading-overlay_loading my-custom-class"
 >
   <div
-    className="ui-loading-overlay__loading-container ui-loading-overlay__loading-container_message-right"
+    className="ui-loading-overlay__loading-container"
   >
     <Spinner
       size="s"
     />
     <span
-      className="ui-loading-overlay__loading-message ui-loading-overlay__loading-message_right"
+      className="ui-loading-overlay__loading-message"
     />
   </div>
   <div
@@ -51,13 +51,13 @@ exports[`LoadingOverlay #render() render loading overlay with left message direc
   className="ui-loading-overlay ui-loading-overlay_loading my-custom-class"
 >
   <div
-    className="ui-loading-overlay__loading-container ui-loading-overlay__loading-container_message-left"
+    className="ui-loading-overlay__loading-container"
   >
     <Spinner
       size="s"
     />
     <span
-      className="ui-loading-overlay__loading-message ui-loading-overlay__loading-message_left"
+      className="ui-loading-overlay__loading-message"
     />
   </div>
   <div
@@ -109,13 +109,13 @@ exports[`LoadingOverlay #render() render loading overlay with transparency in lo
   className="ui-loading-overlay ui-loading-overlay_loading ui-loading-overlay_transparent my-custom-class"
 >
   <div
-    className="ui-loading-overlay__loading-container ui-loading-overlay__loading-container_message-right"
+    className="ui-loading-overlay__loading-container"
   >
     <Spinner
       size="s"
     />
     <span
-      className="ui-loading-overlay__loading-message ui-loading-overlay__loading-message_right"
+      className="ui-loading-overlay__loading-message"
     />
   </div>
   <div

--- a/tests/unit/loadingOverlay/__snapshots__/loadingOverlay.spec.js.snap
+++ b/tests/unit/loadingOverlay/__snapshots__/loadingOverlay.spec.js.snap
@@ -22,9 +22,6 @@ exports[`LoadingOverlay #render() render loading overlay in loading mode 1`] = `
     <Spinner
       size="s"
     />
-    <span
-      className="ui-loading-overlay__loading-message"
-    />
   </div>
   <div
     className="ui-loading-overlay__content"
@@ -55,9 +52,6 @@ exports[`LoadingOverlay #render() render loading overlay with left message direc
   >
     <Spinner
       size="s"
-    />
-    <span
-      className="ui-loading-overlay__loading-message"
     />
   </div>
   <div
@@ -114,9 +108,6 @@ exports[`LoadingOverlay #render() render loading overlay with transparency in lo
     <Spinner
       size="s"
     />
-    <span
-      className="ui-loading-overlay__loading-message"
-    />
   </div>
   <div
     className="ui-loading-overlay__content"
@@ -134,11 +125,7 @@ exports[`LoadingOverlay #render() render without spinner 1`] = `
 >
   <div
     className="ui-loading-overlay__loading-container"
-  >
-    <span
-      className="ui-loading-overlay__loading-message"
-    />
-  </div>
+  />
   <div
     className="ui-loading-overlay__content"
   >

--- a/tests/unit/loadingOverlay/loadingOverlay.spec.js
+++ b/tests/unit/loadingOverlay/loadingOverlay.spec.js
@@ -1,6 +1,7 @@
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import React from 'react';
 import LoadingOverlay from '../../../components/loadingOverlay/loadingOverlay';
+import Spinner from '../../../components/spinner/spinner';
 
 describe('LoadingOverlay', () => {
   describe('#render()', () => {
@@ -83,6 +84,105 @@ describe('LoadingOverlay', () => {
       );
 
       expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should show loading container, once loading finished, show just content', () => {
+      const wrapper = mount(
+        <LoadingOverlay loading message="Loading your data...">
+          Data is loading...
+        </LoadingOverlay>
+      );
+
+      const container = wrapper.find('.ui-loading-overlay');
+      let loadingContainer = wrapper.find('.ui-loading-overlay__loading-container');
+      let content = wrapper.find('.ui-loading-overlay__content');
+      let spinner = wrapper.find(Spinner);
+
+      expect(container.hasClass('ui-loading-overlay_loading')).toEqual(true);
+      expect(loadingContainer).toHaveLength(1);
+      expect(content).toHaveLength(1);
+      expect(content.text()).toEqual('Data is loading...');
+      expect(spinner).toHaveLength(1);
+
+      wrapper.setProps({ loading: false });
+
+      // we need to recheck the toggling elements in the updated tree
+
+      loadingContainer = wrapper.find('.ui-loading-overlay__loading-container');
+      content = wrapper.find('.ui-loading-overlay__content');
+      spinner = wrapper.find(Spinner);
+
+      expect(container.render().hasClass('ui-loading-overlay_loading')).toEqual(false);
+      expect(loadingContainer).toHaveLength(0);
+      expect(content).toHaveLength(1);
+      expect(content.text()).toEqual('Data is loading...');
+      expect(spinner).toHaveLength(0);
+    });
+
+    it('should handle toggling transparency', () => {
+      const wrapper = mount(
+        <LoadingOverlay loading>
+          Data is loading...
+        </LoadingOverlay>
+      );
+
+      const container = wrapper.find('.ui-loading-overlay');
+
+      expect(container.hasClass('ui-loading-overlay_transparent')).toEqual(false);
+
+      wrapper.setProps({ transparency: true });
+
+      expect(container.render().hasClass('ui-loading-overlay_transparent')).toEqual(true);
+
+      wrapper.setProps({ transparency: false });
+
+      expect(container.render().hasClass('ui-loading-overlay_transparent')).toEqual(false);
+    });
+
+    it('should handle toggling spinner', () => {
+      const wrapper = mount(
+        <LoadingOverlay loading>
+          Data is loading...
+        </LoadingOverlay>
+      );
+
+      expect(wrapper.find(Spinner)).toHaveLength(1);
+
+      wrapper.setProps({ spinner: false });
+
+      expect(wrapper.find(Spinner)).toHaveLength(0);
+
+      wrapper.setProps({ spinner: true });
+
+      expect(wrapper.find(Spinner)).toHaveLength(1);
+    });
+
+    it('should handle toggling loading message & its direction; set right direction by default', () => {
+      const wrapper = mount(
+        <LoadingOverlay loading>
+          Data is loading...
+        </LoadingOverlay>
+      );
+
+      expect(wrapper.find('.ui-loading-overlay__loading-message')).toHaveLength(0);
+
+      wrapper.setProps({ message: 'We are loading something...' });
+
+      expect(wrapper.find('.ui-loading-overlay__loading-message')).toHaveLength(1);
+
+      expect(wrapper.find('.ui-loading-overlay__loading-message')
+        .hasClass('ui-loading-overlay__loading-message_right')).toEqual(true);
+
+      expect(wrapper.find('.ui-loading-overlay__loading-container')
+        .hasClass('ui-loading-overlay__loading-container_message-right')).toEqual(true);
+
+      wrapper.setProps({ messageDirection: 'top' });
+
+      expect(wrapper.find('.ui-loading-overlay__loading-message')
+        .hasClass('ui-loading-overlay__loading-message_top')).toEqual(true);
+
+      expect(wrapper.find('.ui-loading-overlay__loading-container')
+        .hasClass('ui-loading-overlay__loading-container_message-top')).toEqual(true);
     });
   });
 });

--- a/tests/unit/loadingOverlay/loadingOverlay.spec.js
+++ b/tests/unit/loadingOverlay/loadingOverlay.spec.js
@@ -1,0 +1,88 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import LoadingOverlay from '../../../components/loadingOverlay/loadingOverlay';
+
+describe('LoadingOverlay', () => {
+  describe('#render()', () => {
+    it('render basic loading overlay', () => {
+      const wrapper = shallow(
+        <LoadingOverlay>
+          Some data
+        </LoadingOverlay>
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('render loading overlay with custom class', () => {
+      const wrapper = shallow(
+        <LoadingOverlay className="my-custom-class">
+          Some data
+        </LoadingOverlay>
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('render loading overlay with transparency', () => {
+      const wrapper = shallow(
+        <LoadingOverlay className="my-custom-class" transparency>
+          Some data
+        </LoadingOverlay>
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('render loading overlay in loading mode', () => {
+      const wrapper = shallow(
+        <LoadingOverlay className="my-custom-class" loading>
+          Data is loading...
+        </LoadingOverlay>
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('render loading overlay with transparency in loading mode', () => {
+      const wrapper = shallow(
+        <LoadingOverlay className="my-custom-class" loading transparency>
+          Data is loading... You can see that message.
+        </LoadingOverlay>
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('render loading overlay with left message direction', () => {
+      const wrapper = shallow(
+        <LoadingOverlay className="my-custom-class" loading messageDirection="left">
+          Data is loading...
+        </LoadingOverlay>
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('render loading overlay with loading message', () => {
+      const wrapper = shallow(
+        <LoadingOverlay className="my-custom-class" loading message="Loading your data...">
+          Data is loading...
+        </LoadingOverlay>
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('render without spinner', () => {
+      const wrapper = shallow(
+        <LoadingOverlay className="my-custom-class" loading spinner={false}>
+          Data is loading...
+        </LoadingOverlay>
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('render without children - should return null', () => {
+      const wrapper = shallow(
+        <LoadingOverlay className="my-custom-class" loading message="Loading your data..." />
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
# What does this PR do:

   This PR fixes the path to Spinner component from the LoadingOverlay component. It now follows the way it's done in other components. Cause: the issue with bundling in our core project (path could not be resolved properly).

# Where should the reviewer start:
  See the diff.
