### PR TITLE
Fix the path to Spinner component from the LoadingOverlay component

### DIFF
--- a/components/loadingOverlay/loadingOverlay.js
+++ b/components/loadingOverlay/loadingOverlay.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { getClassNamesWithMods } from '../_helpers';
-import { Spinner } from '../';
+import Spinner from '../spinner/spinner';
 
 const LoadingOverlay = ({
   children,


### PR DESCRIPTION
# What does this PR do:

   This PR fixes the path to Spinner component from the LoadingOverlay component. It now follows the way it's done in other components. Cause: the issue with bundling in our core project (path cannot be resolved properly).

# Where should the reviewer start:
  See the diff.