### PR TITLE
fixed & improved styles for modal box (according to the design)

### DIFF
--- a/components/modal/modal.js
+++ b/components/modal/modal.js
@@ -143,7 +143,7 @@ class Modal extends Component {
         onClick={this.handleClose}
         type="button"
       >
-        <span>{this.props.closeButtonText}</span>
+        <span className="ui-modal__close-button-text">{this.props.closeButtonText}</span>
       </button>
     );
   }

--- a/components/modal/modal.scss
+++ b/components/modal/modal.scss
@@ -80,18 +80,13 @@
 }
 
 .ui-modal__close-button {
-  align-items: center;
   background: transparent;
   border: 0;
   color: var(--tx-modal-close-button-color);
   cursor: pointer;
-  display: flex;
-  flex-direction: row-reverse;
-  font-size: 13px;
-  justify-content: center;
+  margin-left: 10px;
   outline: 0;
-  position: absolute;
-  right: 24px;
+  padding: 0;
   transition: color .1s ease-in-out;
   z-index: var(--tx-modal-z-index);
 
@@ -99,7 +94,6 @@
     color: var(--tx-modal-close-button-icon-color);
     content: '✖';
     font-size: 20px;
-    margin-left: 9px;
     transition: inherit;
   }
 
@@ -117,7 +111,7 @@
   border-bottom: 2px solid var(--tx-modal-content-devider-color);
   color: var(--tx-modal-color-dark);
   display: flex;
-  flex-shrink: 0;
+  flex-shrink: 1;
   font-family: var(--tx-generic-font-secondary-font-family), var(--tx-generic-font-secondary-generic-family);
   min-height: 13px;
   padding: 24px var(--tx-modal-content-padding-left-right);

--- a/components/modal/modal.scss
+++ b/components/modal/modal.scss
@@ -157,8 +157,6 @@
     max-width: 480px;
   }
   .ui-modal__content {
-    display: flex;
-    flex-direction: column;
     height: 100%;
     padding: 12px;
   }

--- a/components/modal/modal.scss
+++ b/components/modal/modal.scss
@@ -135,9 +135,12 @@
 .ui-modal__content {
   -webkit-overflow-scrolling: touch;
   background-color: var(--tx-generic-color-secondary);
-  height: 100%;
   overflow-y: auto;
   padding: 12px;
+
+  .ui-modal_fullscreen & {
+    height: 100%;
+  }
 }
 
 .ui-modal__footer {
@@ -149,9 +152,5 @@
 .ui-modal_size_small {
   .ui-modal__container {
     max-width: 480px;
-  }
-  .ui-modal__content {
-    height: 100%;
-    padding: 12px;
   }
 }

--- a/components/modal/modal.scss
+++ b/components/modal/modal.scss
@@ -12,7 +12,7 @@
 
   &.ui-modal_active,
   &.ui-modal_open {
-    display:block;
+    display: block;
   }
 }
 
@@ -84,13 +84,17 @@
   border: 0;
   color: var(--tx-modal-close-button-color);
   cursor: pointer;
-  margin-left: 10px;
+  flex: 1 0 auto;
   outline: 0;
   padding: 0;
   transition: color .1s ease-in-out;
   z-index: var(--tx-modal-z-index);
 
-  &:before {
+  .ui-modal__close-button-text {
+    margin: 0 5px;
+  }
+
+  &:after {
     color: var(--tx-modal-close-button-icon-color);
     content: '✖';
     font-size: 20px;
@@ -98,9 +102,9 @@
   }
 
   &:hover {
-   color: var(--tx-modal-close-button-hover-color);
+    color: var(--tx-modal-close-button-hover-color);
 
-    &:before {
+    &:after {
       color: var(--tx-modal-close-button-hover-color);
     }
   }

--- a/components/modal/modalContent.css
+++ b/components/modal/modalContent.css
@@ -3,6 +3,7 @@
   border-radius: var(--tx-generic-border-radius);
   color: var(--tx-generic-color-text-dark);
   font-family: var(--tx-generic-font-secondary-font-family), var(--tx-generic-font-secondary-generic-family);
+  flex: 1 0 auto;
 }
 
 .ui-modal-content-block__title {

--- a/components/modal/modalContent.css
+++ b/components/modal/modalContent.css
@@ -40,10 +40,6 @@
   border-radius: 0;
 }
 
-.ui-modal-content-block:last-of-type {
-  height: 100%;
-}
-
 .ui-modal_size_small .ui-modal-content-block__container {
   padding: 24px;
 }

--- a/tests/unit/modal/__snapshots__/modal.render.spec.js.snap
+++ b/tests/unit/modal/__snapshots__/modal.render.spec.js.snap
@@ -576,7 +576,9 @@ exports[`Modal: render should return base active modal with close button 1`] = `
             onClick={[Function]}
             type="button"
           >
-            <span />
+            <span
+              className="ui-modal__close-button-text"
+            />
           </button>
         </header>
         <section


### PR DESCRIPTION
# What does this PR do:

    - Fixes styles issue on IE 11
was:    
![image 2018-02-07 at 3 34 50 pm](https://user-images.githubusercontent.com/16314636/36154935-4494d5ce-10d3-11e8-8606-87e7b12e3c2b.png)

now:
![screen shot 2018-02-15 at 15 50 40](https://user-images.githubusercontent.com/16314636/36262533-0209e776-1268-11e8-9d11-80ec063c1aff.png)

    - Fixes styles issue on safari 9/10
was:
![screen shot 2018-02-15 at 12 00 37](https://user-images.githubusercontent.com/16314636/36262487-d90c6100-1267-11e8-93ef-7480fffa911a.png)

now:
![screen shot 2018-02-15 at 15 41 16](https://user-images.githubusercontent.com/16314636/36262494-dfdcb1f6-1267-11e8-9ede-a0ce86b1e16a.png)


   - Aligns height of content according to the design (small screen)
was: 
![old](https://user-images.githubusercontent.com/16314636/36154991-6fa9d70a-10d3-11e8-8423-fdc2d92a89f9.png)

now: 
![new](https://user-images.githubusercontent.com/16314636/36155029-8a4a18fe-10d3-11e8-83e4-6d3392a331b1.png)





    
