### PR TITLE
Improve handleClose method to use event

### DIFF
--- a/components/slidingPanel/slidingPanel.js
+++ b/components/slidingPanel/slidingPanel.js
@@ -274,6 +274,9 @@ SlidingPanel.propTypes = {
 
   /**
    * Hook that will be executed when trying to close a panel if exists.
+   * In case, of an event is passed as argument into this function it
+   * was triggered as handler for click on some DOM element.
+   * In another case, panel is trying to close via changing props.
    * If it returns false, the panel won't be closed.
    */
   onTryingToClose: PropTypes.func,

--- a/components/slidingPanel/slidingPanel.js
+++ b/components/slidingPanel/slidingPanel.js
@@ -55,7 +55,7 @@ export default class SlidingPanel extends Component {
    */
   handleClickOverlay(e) {
     if ((e.target === e.currentTarget) && this.props.closeOnOverlayClick) {
-      this.handleClose();
+      this.handleClose(e);
     }
   }
 
@@ -63,12 +63,12 @@ export default class SlidingPanel extends Component {
    * Closes the panel.
    *
    * @method handleClose
-   * @param {SyntheticEvent} e Click event trapped in the overlay element
+   * @param {SyntheticEvent} e Click event trapped in the overlay element or close button
    */
-  handleClose() {
+  handleClose(e) {
     const { onTryingToClose } = this.props;
 
-    if (onTryingToClose && onTryingToClose() === false) {
+    if (onTryingToClose && onTryingToClose(e) === false) {
       return;
     }
 


### PR DESCRIPTION
# What does this PR do:

Needed different behavior for cases when user will click on the cross button and on submit button. For now, I'm not able to distinguish this clicks. Because clicking on any close button or changing component's props will trigger handleClose method and onTryingToClose callback and there are no differences between this calls.

One way, which I found, is to pass the event to handleClose in case of interacting with any DOM element. In case of props are changed arguments will be empty.

# Where should the reviewer start:

diffs