### PR TITLE
Fix option height in dropdown with filter

### DIFF
--- a/components/dropDown/dropDown.md
+++ b/components/dropDown/dropDown.md
@@ -105,7 +105,7 @@ DropDown with filter mode:
     initialState = {filterOptions1: [
       { label: 'One', value: 'One', disabled: true },
       { label: 'Two', value: 'Two', checked: true },
-      { label: 'Three', value: 'Three' },
+      { label: 'Very very very very very long option', value: 'Three' },
       { label: 'Four', value: 'Four' },
     ], filterOptions2: [
       { label: 'One', value: '1' },

--- a/components/dropDown/dropDown.scss
+++ b/components/dropDown/dropDown.scss
@@ -295,7 +295,6 @@ $select-arrow-color: var(--tx-dropdown-arrow-color);
     padding: 5px 15px 5px 20px;
 
     .ui-checkbox__text {
-      height: 16px;
       margin-top: 0;
     }
 


### PR DESCRIPTION
# What does this PR do:

    This PR fixes issue with option height

![drop1](https://user-images.githubusercontent.com/10116899/36679498-69d97c30-1b24-11e8-9bd9-b2d75be07218.png)     ->     ![drop2](https://user-images.githubusercontent.com/10116899/36679503-6bc84774-1b24-11e8-94f3-7ce3919db3d9.png)


# Where should the reviewer start:

    Diff