### PR TITLE
Data attributes for slidingPanelHeader close button

### DIFF
--- a/components/slidingPanel/slidingPanelHeader/slidingPanelHeader.js
+++ b/components/slidingPanel/slidingPanelHeader/slidingPanelHeader.js
@@ -52,7 +52,7 @@ const SlidingPanelHeader = ({
   return (
     <div
       className={headerClassName}
-      {...getDataAttributes(dataAttrs.root)}
+      {...getDataAttributes(dataAttrs.container)}
     >
       <div className="ui-sliding-panel-header__left-block">
         {headerLeftBlock}

--- a/components/slidingPanel/slidingPanelHeader/slidingPanelHeader.js
+++ b/components/slidingPanel/slidingPanelHeader/slidingPanelHeader.js
@@ -7,6 +7,7 @@ const renderDefaultLeftBlock = (backButtonLabel, onBackButtonClick) => (
   <button
     className="ui-sliding-panel-header__left-block-back"
     onClick={onBackButtonClick}
+    {...getDataAttributes(dataAttrs.backButton)}
   >
     <span className="ui-sliding-panel-header__left-block-back-icon" />
 
@@ -23,7 +24,6 @@ const SlidingPanelHeader = ({
   children,
   className,
   dataAttrs,
-  dataAttrsDefaultCloseBtn,
   leftBlock,
   onBackButtonClick,
   rightBlock,
@@ -43,7 +43,7 @@ const SlidingPanelHeader = ({
     <button
       className="ui-sliding-panel-header__close-button"
       data-rel="close"
-      {...getDataAttributes(dataAttrsDefaultCloseBtn)}
+      {...getDataAttributes(dataAttrs.defaultCloseButton)}
     >
       &#215;
     </button>
@@ -52,7 +52,7 @@ const SlidingPanelHeader = ({
   return (
     <div
       className={headerClassName}
-      {...getDataAttributes(dataAttrs)}
+      {...getDataAttributes(dataAttrs.root)}
     >
       <div className="ui-sliding-panel-header__left-block">
         {headerLeftBlock}
@@ -86,14 +86,9 @@ SlidingPanelHeader.propTypes = {
   className: PropTypes.string,
 
   /**
-   * Data attributes. You can use it to set up any custom data-* attribute
+   * Data attributes. You can use it to set up any custom data-* attribute for each element
    */
   dataAttrs: PropTypes.object,
-
-  /**
-   * Data attributes for default close button. You can use it to set up any custom data-* attribute
-   */
-  dataAttrsDefaultCloseBtn: PropTypes.object,
 
   /**
    * When defined, this custom node appears on the left part of the header
@@ -119,6 +114,7 @@ SlidingPanelHeader.propTypes = {
 
 SlidingPanelHeader.defaultProps = {
   useDefaultLeftBlock: false,
+  dataAttrs: {},
 };
 
 export default SlidingPanelHeader;

--- a/components/slidingPanel/slidingPanelHeader/slidingPanelHeader.js
+++ b/components/slidingPanel/slidingPanelHeader/slidingPanelHeader.js
@@ -3,7 +3,7 @@ import React from 'react';
 import classnames from 'classnames';
 import { getDataAttributes } from '../../_helpers';
 
-const renderDefaultLeftBlock = (backButtonLabel, onBackButtonClick) => (
+const renderDefaultLeftBlock = (backButtonLabel, onBackButtonClick, dataAttrs) => (
   <button
     className="ui-sliding-panel-header__left-block-back"
     onClick={onBackButtonClick}
@@ -36,7 +36,7 @@ const SlidingPanelHeader = ({
   const headerClassName = classnames('ui-sliding-panel-header', className);
 
   const headerLeftBlock = useDefaultLeftBlock
-    ? renderDefaultLeftBlock(backButtonLabel, onBackButtonClick)
+    ? renderDefaultLeftBlock(backButtonLabel, onBackButtonClick, dataAttrs)
     : leftBlock;
 
   const defaultCloseButton = (

--- a/components/slidingPanel/slidingPanelHeader/slidingPanelHeader.js
+++ b/components/slidingPanel/slidingPanelHeader/slidingPanelHeader.js
@@ -23,6 +23,7 @@ const SlidingPanelHeader = ({
   children,
   className,
   dataAttrs,
+  dataAttrsDefaultCloseBtn,
   leftBlock,
   onBackButtonClick,
   rightBlock,
@@ -42,6 +43,7 @@ const SlidingPanelHeader = ({
     <button
       className="ui-sliding-panel-header__close-button"
       data-rel="close"
+      {...getDataAttributes(dataAttrsDefaultCloseBtn)}
     >
       &#215;
     </button>
@@ -87,6 +89,11 @@ SlidingPanelHeader.propTypes = {
    * Data attributes. You can use it to set up any custom data-* attribute
    */
   dataAttrs: PropTypes.object,
+
+  /**
+   * Data attributes for default close button. You can use it to set up any custom data-* attribute
+   */
+  dataAttrsDefaultCloseBtn: PropTypes.object,
 
   /**
    * When defined, this custom node appears on the left part of the header

--- a/components/slidingPanel/slidingPanelHeader/slidingPanelHeader.md
+++ b/components/slidingPanel/slidingPanelHeader/slidingPanelHeader.md
@@ -33,14 +33,7 @@ Sliding Panel Header with default block and back button
         active={state.isSlidingPanelOpen}
         onClose={() => setState({ isSlidingPanelOpen: false })}
       >
-        <SlidingPanelHeader
-          backButtonLabel="Back to the website"
-          onBackButtonClick={() => {
-            alert('Going back...');
-            setState({ isSlidingPanelOpen: false });
-          }}
-          useDefaultLeftBlock
-        >
+        <SlidingPanelHeader>
           Panel title
         </SlidingPanelHeader>
 

--- a/tests/unit/slidingPanel/__snapshots__/slidingPanelHeader.spec.js.snap
+++ b/tests/unit/slidingPanel/__snapshots__/slidingPanelHeader.spec.js.snap
@@ -2,12 +2,14 @@
 
 exports[`SlidingPanel #render() render noscript without children 1`] = `
 <SlidingPanelHeader
+  dataAttrs={Object {}}
   useDefaultLeftBlock={false}
 />
 `;
 
 exports[`SlidingPanel #render() render with children 1`] = `
 <SlidingPanelHeader
+  dataAttrs={Object {}}
   useDefaultLeftBlock={false}
 >
   <div
@@ -37,6 +39,7 @@ exports[`SlidingPanel #render() render with children 1`] = `
 
 exports[`SlidingPanel #render() render with custom left and right blocks 1`] = `
 <SlidingPanelHeader
+  dataAttrs={Object {}}
   leftBlock={
     <button
       data-rel="close"
@@ -106,6 +109,7 @@ exports[`SlidingPanel #render() render with custom left and right blocks 1`] = `
 exports[`SlidingPanel #render() should render with backButtonLabel and onBackButtonClick 1`] = `
 <SlidingPanelHeader
   backButtonLabel="foo"
+  dataAttrs={Object {}}
   onBackButtonClick={[MockFunction]}
   useDefaultLeftBlock={true}
 >
@@ -157,14 +161,16 @@ exports[`SlidingPanel #render() should render with dataAttr and className 1`] = 
   className="foo"
   dataAttrs={
     Object {
-      "foo": "bar",
+      "container": Object {
+        "data-gtm-id": "test",
+      },
     }
   }
   useDefaultLeftBlock={false}
 >
   <div
     className="ui-sliding-panel-header foo"
-    data-foo="bar"
+    data-data-gtm-id="test"
   >
     <div
       className="ui-sliding-panel-header__left-block"

--- a/tests/unit/slidingPanel/slidingPanelHeader.spec.js
+++ b/tests/unit/slidingPanel/slidingPanelHeader.spec.js
@@ -92,7 +92,7 @@ describe('SlidingPanel', () => {
       const renderTree = mount(
         <SlidingPanelHeader
           className="foo"
-          dataAttrs={{ foo: 'bar' }}
+          dataAttrs={{ container: { 'data-gtm-id': 'test' } }}
         >
           { title }
         </SlidingPanelHeader>


### PR DESCRIPTION
# What does this PR do:

Need to add a data-gtm-id attribute for close Button for analytics purposes

# Where should the reviewer start:

diffs

# How to use

```
<SlidingPanelHeader
  dataAttrs={{
    container: {
      'gtm-id': '123'
    },
    defaultCloseButton: {
      'xivart-elm': 'cars-sidepanel-close-btn'
    }
    backButton: {
      'xivart-elm': 'cars-sidepanel-title',
      'gtm-id': 312
    }
  }}
>
```
