### PR TITLE
Add class name prop for main container in Badge

### DIFF
--- a/components/badge/badge.js
+++ b/components/badge/badge.js
@@ -15,6 +15,7 @@ const Badge = (props) => {
     border,
     children,
     className,
+    containerClassName,
     dataAttrs = {},
     mods = [],
     position,
@@ -62,7 +63,7 @@ const Badge = (props) => {
   }
 
   return (
-    <div className={getClassNamesWithMods('ui-badge', { visible }, mods)}>
+    <div className={classnames(containerClassName, getClassNamesWithMods('ui-badge', { visible }, mods))}>
       {children}
       {badge}
     </div>
@@ -91,6 +92,10 @@ Badge.propTypes = {
    * Specify a CSS class
    */
   className: PropTypes.string,
+  /**
+   * Class name for main container
+   */
+  containerClassName: PropTypes.string,
   /**
    * Data attribute. You can use it to set up any custom data-* attribute.
    */

--- a/tests/unit/badge/__snapshots__/badge.spec.js.snap
+++ b/tests/unit/badge/__snapshots__/badge.spec.js.snap
@@ -66,6 +66,24 @@ exports[`Badge should render badge with both are position and alignment passed 1
 </div>
 `;
 
+exports[`Badge should render badge with main container class name 1`] = `
+<div
+  className="my-container-class ui-badge ui-badge_visible"
+>
+  <p>
+    Children element
+  </p>
+  <div
+    className="ui-badge-badge ui-badge-badge_start"
+  >
+    Badge title
+    <div
+      className="ui-badge__border"
+    />
+  </div>
+</div>
+`;
+
 exports[`Badge should render badge with provided className 1`] = `
 <div
   className="test-class ui-badge-badge ui-badge-badge_start"

--- a/tests/unit/badge/badge.spec.js
+++ b/tests/unit/badge/badge.spec.js
@@ -136,4 +136,14 @@ describe('Badge', () => {
 
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should render badge with main container class name', () => {
+    const wrapper = shallow(
+      <Badge containerClassName="my-container-class" title="Badge title">
+        <p>Children element</p>
+      </Badge>
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
# What does this PR do:
* Introduce a new prop for being able to control class name of the main container in Badge component

# Where should the reviewer start:
* Diff
